### PR TITLE
Use httpasyncclient to invoke analytics engine

### DIFF
--- a/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/pom.xml
@@ -105,6 +105,10 @@
             <groupId>org.wso2.msf4j</groupId>
             <artifactId>msf4j-microservice</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
+            <artifactId>httpasyncclient</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -164,6 +168,12 @@
                             org.apache.http.impl.conn,
                             org.osgi.framework,
                             org.wso2.carbon.base.api,
+                            org.apache.http.impl.nio.*,
+                            org.apache.http.concurrent,
+                            org.apache.http.nio.*,
+                            org.apache.axis2.context,
+                            org.wso2.carbon.utils,
+                            org.wso2.carbon.context,
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/analytics/CallAnalyticsFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/analytics/CallAnalyticsFunctionImpl.java
@@ -127,11 +127,11 @@ public class CallAnalyticsFunctionImpl extends AbstractAnalyticsFunction impleme
                                         asyncReturn.accept(authenticationContext, json, OUTCOME_SUCCESS);
                                     } catch (ParseException e) {
                                         LOG.error("Error while building response from analytics engine call for " +
-                                                "session data key: " + authenticationContext.getContextIdentifier());
+                                                "session data key: " + authenticationContext.getContextIdentifier(), e);
                                         asyncReturn.accept(authenticationContext, Collections.emptyMap(), OUTCOME_FAIL);
                                     } catch (IOException e) {
                                         LOG.error("Error while reading response from analytics engine call for " +
-                                                "session data key: " + authenticationContext.getContextIdentifier());
+                                                "session data key: " + authenticationContext.getContextIdentifier(), e);
                                         asyncReturn.accept(authenticationContext, Collections.emptyMap(), OUTCOME_FAIL);
                                     }
                                 } else {
@@ -139,15 +139,22 @@ public class CallAnalyticsFunctionImpl extends AbstractAnalyticsFunction impleme
                                 }
                             } catch (FrameworkException e) {
                                 LOG.error("Error while proceeding after successful response from analytics engine " +
-                                        "call for session data key: " + authenticationContext.getContextIdentifier());
+                                        "call for session data key: " + authenticationContext.getContextIdentifier(),
+                                        e);
                             }
                         }
 
                         @Override
                         public void failed(final Exception ex) {
 
+                            LOG.error("Failed to invoke analytics engine for session data key: " +
+                                    authenticationContext.getContextIdentifier(), ex);
                             if (requestAtomicInteger.decrementAndGet() <= 0) {
                                 try {
+                                    if (LOG.isDebugEnabled()) {
+                                        LOG.debug(" All the calls to analytics engine failed for session " +
+                                                "data key: " + authenticationContext.getContextIdentifier());
+                                    }
                                     String outcome = OUTCOME_FAIL;
                                     if ((ex instanceof SocketTimeoutException)
                                             || (ex instanceof ConnectTimeoutException)) {
@@ -156,7 +163,8 @@ public class CallAnalyticsFunctionImpl extends AbstractAnalyticsFunction impleme
                                     asyncReturn.accept(authenticationContext, Collections.emptyMap(), outcome);
                                 } catch (FrameworkException e) {
                                     LOG.error("Error while proceeding after failed response from analytics engine " +
-                                            "call for session data key: " + authenticationContext.getContextIdentifier());
+                                            "call for session data key: " + authenticationContext
+                                            .getContextIdentifier(), e);
                                 }
                             }
                         }
@@ -164,12 +172,19 @@ public class CallAnalyticsFunctionImpl extends AbstractAnalyticsFunction impleme
                         @Override
                         public void cancelled() {
 
+                            LOG.error("Invocation analytics engine for session data key: " +
+                                    authenticationContext.getContextIdentifier() + " is cancelled.");
                             if (requestAtomicInteger.decrementAndGet() <= 0) {
                                 try {
+                                    if (LOG.isDebugEnabled()) {
+                                        LOG.debug(" All the calls to analytics engine failed for session " +
+                                                "data key: " + authenticationContext.getContextIdentifier());
+                                    }
                                     asyncReturn.accept(authenticationContext, Collections.emptyMap(), OUTCOME_FAIL);
                                 } catch (FrameworkException e) {
                                     LOG.error("Error while proceeding after cancelled response from analytics engine " +
-                                            "call for session data key: " + authenticationContext.getContextIdentifier());
+                                            "call for session data key: " + authenticationContext
+                                            .getContextIdentifier(), e);
                                 }
                             }
                         }

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/analytics/ClientManager.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/analytics/ClientManager.java
@@ -24,15 +24,24 @@ import org.apache.http.client.config.RequestConfig;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLContexts;
 import org.apache.http.conn.ssl.X509HostnameVerifier;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.impl.nio.client.HttpAsyncClients;
+import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
+import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
+import org.apache.http.nio.reactor.ConnectingIOReactor;
+import org.apache.http.nio.reactor.IOReactorException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.conditional.auth.functions.analytics.internal.AnalyticsFunctionsServiceHolder;
 import org.wso2.carbon.identity.conditional.auth.functions.common.utils.CommonUtils;
 import org.wso2.carbon.identity.conditional.auth.functions.common.utils.Constants;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventException;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import javax.net.ssl.SSLContext;
 
 /**
@@ -42,9 +51,9 @@ public class ClientManager {
 
     private static final Log LOG = LogFactory.getLog(ClientManager.class);
 
-    private PoolingHttpClientConnectionManager poolingHttpClientConnectionManager;
-
     private static ClientManager instance = new ClientManager();
+
+    private static Map<Integer, CloseableHttpAsyncClient> clientMap = new HashMap<>();
 
     public static ClientManager getInstance() {
 
@@ -53,29 +62,6 @@ public class ClientManager {
 
     private ClientManager() {
 
-        String maxConnectionsString = IdentityUtil.getProperty(Constants.CONNECTION_POOL_MAX_CONNECTIONS);
-        String maxConnectionsPerRouteString = IdentityUtil.getProperty(Constants
-                .CONNECTION_POOL_MAX_CONNECTIONS_PER_ROUTE);
-        int defaultMaxConnections = 20;
-        int maxConnections = defaultMaxConnections;
-        int maxConnectionsPerRoute = defaultMaxConnections;
-        try {
-            maxConnections = Integer.parseInt(maxConnectionsString);
-        } catch (NumberFormatException e) {
-            // Ignore. Default value is used.
-        }
-        try {
-            maxConnectionsPerRoute = Integer.parseInt(maxConnectionsPerRouteString);
-        } catch (NumberFormatException e) {
-            // Ignore. Default value is used.
-        }
-
-
-        poolingHttpClientConnectionManager = new PoolingHttpClientConnectionManager();
-        // Increase max total connection to 50
-        poolingHttpClientConnectionManager.setMaxTotal(maxConnections);
-        // Increase default max connection per route to 50
-        poolingHttpClientConnectionManager.setDefaultMaxPerRoute(maxConnectionsPerRoute);
     }
 
     /**
@@ -84,9 +70,31 @@ public class ClientManager {
      * @param tenantDomain tenant domain of the service provider.
      * @return HttpClient
      */
-    public CloseableHttpClient getClient(String tenantDomain) {
+    public CloseableHttpAsyncClient getClient(String tenantDomain) throws FrameworkException {
 
-        CloseableHttpClient client;
+        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+        CloseableHttpAsyncClient client = clientMap.get(tenantId);
+
+        if (client == null) {
+
+            PoolingNHttpClientConnectionManager poolingHttpClientConnectionManager = createPoolingConnectionManager();
+
+            RequestConfig config = createRequestConfig(tenantDomain);
+
+            HttpAsyncClientBuilder httpClientBuilder = HttpAsyncClients.custom().setDefaultRequestConfig(config);
+
+            addSslContext(httpClientBuilder, tenantDomain);
+            httpClientBuilder.setConnectionManager(poolingHttpClientConnectionManager);
+
+            client = httpClientBuilder.build();
+            client.start();
+            clientMap.put(tenantId, client);
+        }
+
+        return client;
+    }
+
+    private RequestConfig createRequestConfig(String tenantDomain) {
 
         int defaultTimeout = 5000;
         String connectionTimeoutString = null;
@@ -137,22 +145,58 @@ public class ClientManager {
             }
         }
 
-        RequestConfig config = RequestConfig.custom()
+        return RequestConfig.custom()
                 .setConnectTimeout(connectionTimeout)
                 .setConnectionRequestTimeout(connectionRequestTimeout)
                 .setSocketTimeout(readTimeout)
                 .build();
-        HttpClientBuilder httpClientBuilder = HttpClientBuilder.create().setDefaultRequestConfig(config);
-
-        addSslContext(httpClientBuilder, tenantDomain);
-        addConnectionManager(httpClientBuilder);
-
-        client = httpClientBuilder.build();
-
-        return client;
     }
 
-    private void addSslContext(HttpClientBuilder builder, String tenantDomain) {
+    private PoolingNHttpClientConnectionManager createPoolingConnectionManager() throws FrameworkException {
+
+        String maxConnectionsString = IdentityUtil.getProperty(Constants.CONNECTION_POOL_MAX_CONNECTIONS);
+        String maxConnectionsPerRouteString = IdentityUtil.getProperty(Constants
+                .CONNECTION_POOL_MAX_CONNECTIONS_PER_ROUTE);
+        int defaultMaxConnections = 20;
+        int maxConnections = defaultMaxConnections;
+        int maxConnectionsPerRoute = defaultMaxConnections;
+        try {
+            maxConnections = Integer.parseInt(maxConnectionsString);
+        } catch (NumberFormatException e) {
+            // Ignore. Default value is used.
+        }
+        try {
+            maxConnectionsPerRoute = Integer.parseInt(maxConnectionsPerRouteString);
+        } catch (NumberFormatException e) {
+            // Ignore. Default value is used.
+        }
+
+        ConnectingIOReactor ioReactor;
+        try {
+            ioReactor = new DefaultConnectingIOReactor();
+        } catch (IOReactorException e) {
+            throw new FrameworkException("Error while creating ConnectingIOReactor", e);
+        }
+        PoolingNHttpClientConnectionManager poolingHttpClientConnectionManager = new
+                PoolingNHttpClientConnectionManager(ioReactor);
+        // Increase max total connection to 50
+        poolingHttpClientConnectionManager.setMaxTotal(maxConnections);
+        // Increase default max connection per route to 50
+        poolingHttpClientConnectionManager.setDefaultMaxPerRoute(maxConnectionsPerRoute);
+        return poolingHttpClientConnectionManager;
+    }
+
+    public void closeClient(int tenantId) throws IOException {
+
+        CloseableHttpAsyncClient client = clientMap.get(tenantId);
+
+        if (client != null) {
+            clientMap.remove(tenantId);
+            client.close();
+        }
+    }
+
+    private void addSslContext(HttpAsyncClientBuilder builder, String tenantDomain) {
 
         try {
             SSLContext sslContext = SSLContexts.custom()
@@ -169,21 +213,13 @@ public class ClientManager {
             } else {
                 hostnameVerifier = SSLConnectionSocketFactory.STRICT_HOSTNAME_VERIFIER;
             }
-            SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(
-                    sslContext,
-                    null,
-                    null,
-                    hostnameVerifier);
 
-            builder.setSSLSocketFactory(sslSocketFactory);
+            builder.setSSLContext(sslContext);
+            builder.setHostnameVerifier(hostnameVerifier);
         } catch (Exception e) {
             LOG.error("Error while creating ssl context for analytics endpoint invocation in tenant domain: " +
                     tenantDomain, e);
         }
     }
 
-    private void addConnectionManager(HttpClientBuilder builder) {
-
-        builder.setConnectionManager(poolingHttpClientConnectionManager);
-    }
 }

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/analytics/internal/AnalyticsFunctionsServiceComponent.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/analytics/internal/AnalyticsFunctionsServiceComponent.java
@@ -35,9 +35,11 @@ import org.wso2.carbon.identity.conditional.auth.functions.analytics.CallAnalyti
 import org.wso2.carbon.identity.conditional.auth.functions.analytics.CallAnalyticsFunctionImpl;
 import org.wso2.carbon.identity.conditional.auth.functions.analytics.PublishToAnalyticsFunction;
 import org.wso2.carbon.identity.conditional.auth.functions.analytics.PublishToAnalyticsFunctionImpl;
+import org.wso2.carbon.identity.conditional.auth.functions.analytics.listener.AnalyticsAxis2ConfigurationContextObserver;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
+import org.wso2.carbon.utils.Axis2ConfigurationContextObserver;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -78,6 +80,9 @@ public class AnalyticsFunctionsServiceComponent {
             BundleContext bundleContext = context.getBundleContext();
             AnalyticsEngineConfigImpl analyticsFunctionConfig = new AnalyticsEngineConfigImpl();
             bundleContext.registerService(IdentityConnectorConfig.class.getName(), analyticsFunctionConfig, null);
+
+            AnalyticsAxis2ConfigurationContextObserver observer = new AnalyticsAxis2ConfigurationContextObserver();
+            bundleContext.registerService(Axis2ConfigurationContextObserver.class.getName(), observer, null);
 
             ServerConfigurationService config = AnalyticsFunctionsServiceHolder.getInstance()
                     .getServerConfigurationService();

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/analytics/listener/AnalyticsAxis2ConfigurationContextObserver.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/analytics/listener/AnalyticsAxis2ConfigurationContextObserver.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.conditional.auth.functions.analytics.listener;
+
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.conditional.auth.functions.analytics.ClientManager;
+import org.wso2.carbon.utils.AbstractAxis2ConfigurationContextObserver;
+
+import java.io.IOException;
+
+/**
+ * This class is responsible for closing the http client used for the tenant when the tenant is unloaded.
+ */
+public class AnalyticsAxis2ConfigurationContextObserver extends
+        AbstractAxis2ConfigurationContextObserver {
+
+    private static final Log log = LogFactory.getLog(
+            AnalyticsAxis2ConfigurationContextObserver.class);
+
+    public void terminatingConfigurationContext(ConfigurationContext configContext) {
+
+        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+        try {
+            ClientManager.getInstance().closeClient(tenantId);
+        } catch (IOException e) {
+            log.error("Error while closing http client for tenant: " + tenantId, e);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,11 @@
                 <artifactId>json-simple</artifactId>
                 <version>${com.googlecode.json-simple.wso2.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
+                <artifactId>httpasyncclient</artifactId>
+                <version>${httpasyncclient.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.jacoco</groupId>
@@ -395,6 +400,6 @@
         <com.googlecode.json-simple.wso2.version>1.1.wso2v1</com.googlecode.json-simple.wso2.version>
         <ua_parser.version>1.3.0.wso2v1</ua_parser.version>
         <msf4j.version>2.6.2</msf4j.version>
-
+        <httpasyncclient.version>4.0.2.wso2v1</httpasyncclient.version>
     </properties>
 </project>


### PR DESCRIPTION
## Purpose

- Use httpasyncclient to invoke analytics engine.
- Create tenant-wise http client and clean the client properly when the tenant is unloaded.

