### PR TITLE
Fix tests failure when the carbon-identity-framework version is upgraded

### DIFF
--- a/components/org.wso2.carbon.identity.conditional.auth.functions.test.utils/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/test/utils/sequence/JsSequenceHandlerAbstractTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.test.utils/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/test/utils/sequence/JsSequenceHandlerAbstractTest.java
@@ -67,7 +67,7 @@ public class JsSequenceHandlerAbstractTest {
                     try (FileOutputStream fos = new FileOutputStream(f)) {
                         targetChannel = fos.getChannel();
                         //Transfer data from input channel to output channel
-                        ((FileChannel) targetChannel).transferFrom(inputChannel, 0, Short.MAX_VALUE);
+                        ((FileChannel) targetChannel).transferFrom(inputChannel, 0, Long.MAX_VALUE);
                     }
                 }
                 inputStream.close();


### PR DESCRIPTION
Resolves #47 