### PR TITLE
Use the value mapped to IDP's user id claim uri as external subject,  when claim mappings are defined

### DIFF
--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/pom.xml
@@ -141,7 +141,9 @@
                             org.wso2.carbon.user.core; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.util; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.common; version="${carbon.kernel.package.import.version.range}",
-                            org.wso2.carbon.user.core.service; version="${carbon.kernel.package.import.version.range}"
+                            org.wso2.carbon.user.core.service; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.idp.mgt.*,
+                            org.wso2.carbon.identity.application.common.*,
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/SetAccountAssociationToLocalUserImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/SetAccountAssociationToLocalUserImpl.java
@@ -18,12 +18,23 @@
 
 package org.wso2.carbon.identity.conditional.auth.functions.user;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.JsAuthenticatedUser;
+import org.wso2.carbon.identity.application.common.model.ClaimConfig;
+import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.user.profile.mgt.UserProfileException;
 import org.wso2.carbon.identity.user.profile.mgt.dao.UserProfileMgtDAO;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementService;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 
 public class SetAccountAssociationToLocalUserImpl implements SetAccountAssociationToLocalUser {
 
@@ -33,29 +44,75 @@ public class SetAccountAssociationToLocalUserImpl implements SetAccountAssociati
     public void doAssociationWithLocalUser(JsAuthenticatedUser federatedUser, String username, String tenantDomain,
                                            String userStoreDomainName) {
 
-        if (federatedUser != null) {
-            if (federatedUser.getWrapped().isFederatedUser()) {
-                String externalSubject = federatedUser.getWrapped().getAuthenticatedSubjectIdentifier();
-                String externalIdpName = federatedUser.getWrapped().getFederatedIdPName();
-                if (externalSubject != null && externalIdpName != null) {
-                    associateID(externalIdpName, externalSubject, username, tenantDomain, userStoreDomainName);
+        String federatedIdpName = null;
+        try {
+            if (federatedUser != null) {
+                if (federatedUser.getWrapped().isFederatedUser()) {
+                    federatedIdpName = federatedUser.getWrapped().getFederatedIdPName();
+                    String userIdClaimURI = getUserIdClaimURI(federatedIdpName);
+                    String externalSubject;
+                    if (StringUtils.isNotEmpty(userIdClaimURI)) {
+                        externalSubject = federatedUser.getWrapped().getUserAttributes().entrySet().stream().filter(
+                                userAttribute -> userAttribute.getKey().getRemoteClaim().getClaimUri()
+                                        .equals(userIdClaimURI))
+                                .map(Map.Entry::getValue)
+                                .findFirst()
+                                .orElse(null);
+                    } else {
+                        externalSubject = federatedUser.getWrapped().getAuthenticatedSubjectIdentifier();
+                    }
+                    String externalIdpName = federatedUser.getWrapped().getFederatedIdPName();
+                    if (externalSubject != null && externalIdpName != null) {
+                        associateID(externalIdpName, externalSubject, username, tenantDomain, userStoreDomainName);
+                    } else {
+                        if (log.isDebugEnabled()) {
+                            log.debug(" Authenticated user or External IDP may be null " + " Authenticated User: " +
+                                    externalSubject + " and the External IDP name: " + externalIdpName);
+                        }
+                    }
                 } else {
                     if (log.isDebugEnabled()) {
-                        log.debug(" Authenticated user or External IDP may be null " + " Authenticated User: " +
-                                externalSubject + " and the External IDP name: " + externalIdpName);
+                        log.debug("User " + federatedUser.getWrapped().getAuthenticatedSubjectIdentifier() + " " +
+                                "is not a federated user.");
                     }
                 }
             } else {
                 if (log.isDebugEnabled()) {
-                    log.debug("User " + federatedUser.getWrapped().getAuthenticatedSubjectIdentifier() + " " +
-                            "is not a federated user." );
+                    log.debug(" Federated user is null ");
                 }
             }
-        } else {
-            if (log.isDebugEnabled()) {
-                log.debug(" Federated user is null ");
-            }
+        } catch (IdentityProviderManagementException e) {
+            String msg =
+                    "Error while retrieving identity provider by name: " + federatedIdpName;
+            log.error(msg, e);
         }
+    }
+
+    private String getUserIdClaimURI(String federatedIdpName) throws IdentityProviderManagementException {
+
+        String userIdClaimURI = null;
+        String userNameLocalClaim = "http://wso2.org/claims/username";
+        IdentityProviderManagementService idpManager = new IdentityProviderManagementService();
+        IdentityProvider idp = idpManager.getIdPByName(federatedIdpName);
+        if (idp == null) {
+            return null;
+        }
+        ClaimConfig claimConfigs = idp.getClaimConfig();
+        if (claimConfigs == null) {
+            return null;
+        }
+        ClaimMapping[] claimMappings = claimConfigs.getClaimMappings();
+        if (CollectionUtils.isEmpty(Collections.singleton(userIdClaimURI))) {
+            return null;
+        }
+        ClaimMapping userNameClaimMapping = Arrays.stream(claimMappings).filter(claimMapping ->
+                StringUtils.equals(userNameLocalClaim, claimMapping.getLocalClaim().getClaimUri()))
+                .findFirst()
+                .orElse(null);
+        if (userNameClaimMapping != null) {
+            userIdClaimURI = userNameClaimMapping.getRemoteClaim().getClaimUri();
+        }
+        return userIdClaimURI;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/internal/UserFunctionsServiceComponent.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/internal/UserFunctionsServiceComponent.java
@@ -48,6 +48,7 @@ import org.wso2.carbon.identity.conditional.auth.functions.user.RemoveUserRolesF
 import org.wso2.carbon.identity.conditional.auth.functions.user.TerminateUserSessionImpl;
 import org.wso2.carbon.identity.conditional.auth.functions.user.SetAccountAssociationToLocalUserImpl;
 import org.wso2.carbon.identity.conditional.auth.functions.user.SetAccountAssociationToLocalUser;
+import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.service.RealmService;
 
@@ -206,6 +207,29 @@ public class UserFunctionsServiceComponent {
     public void unsetJsFunctionRegistry(JsFunctionRegistry jsFunctionRegistry) {
 
         UserFunctionsServiceHolder.getInstance().setJsFunctionRegistry(null);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.idp.mgt.IdpManager",
+            service = IdpManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdentityProviderManagementService"
+    )
+    protected void setIdentityProviderManagementService(IdpManager idpManager) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("IdpManager service is set in the conditional authentication user functions bundle");
+        }
+        UserFunctionsServiceHolder.getInstance().setIdentityProviderManagementService(idpManager);
+    }
+
+    protected void unsetIdentityProviderManagementService(IdpManager idpManager) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("IdpManager service is unset in the conditional authentication user functions bundle");
+        }
+        UserFunctionsServiceHolder.getInstance().setIdentityProviderManagementService(null);
     }
 
 }

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/internal/UserFunctionsServiceHolder.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/internal/UserFunctionsServiceHolder.java
@@ -20,6 +20,8 @@ package org.wso2.carbon.identity.conditional.auth.functions.user.internal;
 
 import org.wso2.carbon.identity.application.authentication.framework.JsFunctionRegistry;
 import org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementService;
+import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.service.RealmService;
 
@@ -30,6 +32,7 @@ public class UserFunctionsServiceHolder {
     private RealmService realmService;
     private RegistryService registryService;
     private UserSessionManagementService userSessionManagementService;
+    private IdpManager identityProviderManagementService;
     private JsFunctionRegistry jsFunctionRegistry;
 
     private UserFunctionsServiceHolder() {
@@ -71,6 +74,16 @@ public class UserFunctionsServiceHolder {
 
         this.userSessionManagementService = userSessionManagementService;
 
+    }
+
+    public IdpManager getIdentityProviderManagementService() {
+
+        return identityProviderManagementService;
+    }
+
+    public void setIdentityProviderManagementService(IdpManager identityProviderManagementService) {
+
+        this.identityProviderManagementService = identityProviderManagementService;
     }
 
     public JsFunctionRegistry getJsFunctionRegistry() {


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-is/issues/11586
When adding federated user association,
Use IDP's user id claim URI as the external subject when claim mappings are defined for IDP. Otherwise use the federated user's subject identitfier.