### PR TITLE
Update user Id retrieval approach in terminateUserSession function

### DIFF
--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/GetUserSessionsFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/GetUserSessionsFunctionImpl.java
@@ -22,16 +22,13 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.JsAuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
-import org.wso2.carbon.identity.application.authentication.framework.exception.UserSessionException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.session.mgt.SessionManagementException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.model.UserSession;
-import org.wso2.carbon.identity.application.authentication.framework.store.UserSessionStore;
-import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.conditional.auth.functions.user.exception.UserSessionRetrievalException;
 import org.wso2.carbon.identity.conditional.auth.functions.user.internal.UserFunctionsServiceHolder;
 import org.wso2.carbon.identity.conditional.auth.functions.user.model.JsUserSession;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.user.core.UserRealm;
 
 import java.util.List;
@@ -62,14 +59,11 @@ public class GetUserSessionsFunctionImpl implements GetUserSessionsFunction {
 
         List<UserSession> userSessions = null;
         String tenantDomain = authenticatedUser.getTenantDomain();
-        String userStoreDomain = authenticatedUser.getUserStoreDomain();
-        String username = authenticatedUser.getUserName();
 
         try {
             UserRealm userRealm = Utils.getUserRealm(tenantDomain);
             if (userRealm != null) {
-                String userId = FrameworkUtils.resolveUserIdFromUsername(IdentityTenantUtil.getTenantIdOfUser(username),
-                        userStoreDomain, username);
+                String userId = authenticatedUser.getUserId();
                 userSessions = UserFunctionsServiceHolder.getInstance()
                         .getUserSessionManagementService().getSessionsByUserId(userId);
             }
@@ -77,7 +71,7 @@ public class GetUserSessionsFunctionImpl implements GetUserSessionsFunction {
             throw new UserSessionRetrievalException("Error occurred while retrieving sessions: ", e);
         } catch (FrameworkException e) {
             throw new UserSessionRetrievalException("Error in evaluating the function ", e);
-        } catch (UserSessionException e) {
+        } catch (UserIdNotFoundException e) {
             throw new UserSessionRetrievalException("Error occurred while retrieving the UserID: ", e);
         }
         return userSessions;

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/TerminateUserSessionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/TerminateUserSessionImpl.java
@@ -25,7 +25,7 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.F
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserSessionException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.session.mgt.SessionManagementException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
-import org.wso2.carbon.identity.application.authentication.framework.store.UserSessionStore;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.conditional.auth.functions.user.exception.UserSessionTerminationException;
 import org.wso2.carbon.identity.conditional.auth.functions.user.internal.UserFunctionsServiceHolder;
 import org.wso2.carbon.user.core.UserRealm;
@@ -59,8 +59,8 @@ public class TerminateUserSessionImpl implements TerminateUserSession {
         try {
             UserRealm userRealm = Utils.getUserRealm(tenantDomain);
             if (userRealm != null) {
-                String userId = UserSessionStore.getInstance()
-                        .getUserId(username, Utils.getTenantId(tenantDomain), userStoreDomain);
+                String userId = FrameworkUtils.resolveUserIdFromUsername(Utils.getTenantId(tenantDomain),
+                        userStoreDomain, username);
                 result = UserFunctionsServiceHolder.getInstance()
                         .getUserSessionManagementService().terminateSessionBySessionId(userId, sessionId);
             }

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/TerminateUserSessionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/TerminateUserSessionImpl.java
@@ -22,10 +22,9 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.JsAuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
-import org.wso2.carbon.identity.application.authentication.framework.exception.UserSessionException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.session.mgt.SessionManagementException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
-import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.conditional.auth.functions.user.exception.UserSessionTerminationException;
 import org.wso2.carbon.identity.conditional.auth.functions.user.internal.UserFunctionsServiceHolder;
 import org.wso2.carbon.user.core.UserRealm;
@@ -53,14 +52,12 @@ public class TerminateUserSessionImpl implements TerminateUserSession {
 
         boolean result = false;
         String tenantDomain = authenticatedUser.getTenantDomain();
-        String userStoreDomain = authenticatedUser.getUserStoreDomain();
         String username = authenticatedUser.getUserName();
 
         try {
             UserRealm userRealm = Utils.getUserRealm(tenantDomain);
             if (userRealm != null) {
-                String userId = FrameworkUtils.resolveUserIdFromUsername(Utils.getTenantId(tenantDomain),
-                        userStoreDomain, username);
+                String userId = authenticatedUser.getUserId();
                 result = UserFunctionsServiceHolder.getInstance()
                         .getUserSessionManagementService().terminateSessionBySessionId(userId, sessionId);
             }
@@ -69,12 +66,12 @@ public class TerminateUserSessionImpl implements TerminateUserSession {
             }
         } catch (FrameworkException e) {
             throw new UserSessionTerminationException("Error in evaluating the function ", e);
-        } catch (UserSessionException e) {
-            throw new UserSessionTerminationException
-                    ("Error occurred while retrieving the UserID for user: " + username, e);
         } catch (SessionManagementException e) {
             throw new UserSessionTerminationException
                     ("Error occurred while terminating the user session for sessionId: " + sessionId, e);
+        } catch (UserIdNotFoundException e) {
+            throw new UserSessionTerminationException
+                    ("Error occurred while retrieving the UserID for user: " + username, e);
         }
         return result;
     }


### PR DESCRIPTION
## Purpose
> Fix https://github.com/wso2/product-is/issues/12812
> The user Id of the user was being retrirved from the IDN_AUTH_USER table, and as local user records are not inserted to the table, the user Id was returning a null and thus session termination was a failure. 

## Goals
> To retrieve user Id from the userstore based on given parameters.

## Approach
> Updated method of retrieving user Id at session termination function. 
