### PR TITLE
Fix Signing or encrypting of tokens gives unexpected result issue

### DIFF
--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/pom.xml
@@ -103,6 +103,12 @@
             <artifactId>msf4j-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <artifactId>org.wso2.carbon.crypto.impl</artifactId>
+            <groupId>org.wso2.carbon.crypto</groupId>
+            <version>1.1.13</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/pom.xml
@@ -104,9 +104,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <artifactId>org.wso2.carbon.crypto.impl</artifactId>
             <groupId>org.wso2.carbon.crypto</groupId>
-            <version>1.1.13</version>
+            <artifactId>org.wso2.carbon.crypto.impl</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/CookieFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/CookieFunctionImpl.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.conditional.auth.functions.http.util.HTTPConstants;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -76,7 +77,8 @@ public class CookieFunctionImpl implements SetCookieFunction, GetCookieFunction 
             }
             if (encrypt) {
                 try {
-                    value = CryptoUtil.getDefaultCryptoUtil().encryptAndBase64Encode(Base64.decode(value));
+                    value = CryptoUtil.getDefaultCryptoUtil().encryptAndBase64Encode(
+                            value.getBytes(StandardCharsets.UTF_8));
                 } catch (CryptoException e) {
                     log.error("Error occurred when encrypting the cookie value.", e);
                     return;
@@ -150,8 +152,8 @@ public class CookieFunctionImpl implements SetCookieFunction, GetCookieFunction 
                             .orElse(false);
                     if (decrypt) {
                         try {
-                            valueString = Base64.encode(CryptoUtil.getDefaultCryptoUtil()
-                                    .base64DecodeAndDecrypt(valueString));
+                            valueString = new String(CryptoUtil.getDefaultCryptoUtil()
+                                    .base64DecodeAndDecrypt(valueString), StandardCharsets.UTF_8);
                         } catch (CryptoException e) {
                             log.error("Error occurred when decrypting the cookie value.", e);
                             return null;

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/CookieFunctionImplTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/CookieFunctionImplTest.java
@@ -152,6 +152,18 @@ public class CookieFunctionImplTest extends JsSequenceHandlerAbstractTest {
         internalTestSetAndGetCookieValues(inputCookieValue, shouldEncrypt, shouldDecrypt, shouldSign);
     }
 
+    @DataProvider(name = "cookieValues")
+    public Object[][] getCookieValues() {
+
+        return new Object[][]{
+                {"Test"},
+                {"1234"},
+                {"Test1234"},
+                {"asgh@123&*()!@#$"},
+                {"{\"usr\" : \"" + "JohnDoe" + "\", \"str\" : \"" + "PRIMARY" + "\"}"}
+        };
+    }
+
     private void internalTestSetAndGetCookieValues(String inputCookieValue, boolean shouldEncrypt,
                                                    boolean shouldDecrypt, boolean shouldSign) throws JsTestException {
 
@@ -181,18 +193,6 @@ public class CookieFunctionImplTest extends JsSequenceHandlerAbstractTest {
         String value = cookieFunction.getCookieValue(jsServletRequest, name, getCookieParams );
 
         Assert.assertEquals(value, inputCookieValue);
-    }
-
-    @DataProvider(name = "cookieValues")
-    public Object[][] getCookieValues() {
-
-        return new Object[][]{
-                {"Test"},
-                {"1234"},
-                {"Test1234"},
-                {"asgh@123&*()!@#$"},
-                {"{\"usr\" : \"" + "JohnDoe" + "\", \"str\" : \"" + "PRIMARY" + "\"}"}
-        };
     }
 
     private class MockServletRequestWithCookie extends JsSequenceHandlerRunner.MockServletRequest {

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/CookieFunctionImplTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/CookieFunctionImplTest.java
@@ -25,8 +25,15 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.core.internal.CarbonCoreDataHolder;
+import org.wso2.carbon.crypto.impl.DefaultCryptoService;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.JsServletRequest;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.JsServletResponse;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.nashorn.JsNashornServletRequest;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.nashorn.JsNashornServletResponse;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.context.TransientObjectWrapper;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
@@ -43,6 +50,9 @@ import org.wso2.carbon.identity.conditional.auth.functions.test.utils.sequence.J
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.mockito.Mockito.verify;
 
@@ -61,6 +71,9 @@ public class CookieFunctionImplTest extends JsSequenceHandlerAbstractTest {
         sequenceHandlerRunner.registerJsFunction("setCookie", (SetCookieFunction) new CookieFunctionImpl()::setCookie);
         sequenceHandlerRunner.registerJsFunction("getCookieValue", (GetCookieFunction) new CookieFunctionImpl()
                 ::getCookieValue);
+        DefaultCryptoService defaultCryptoService = new DefaultCryptoService();
+        defaultCryptoService.registerInternalCryptoProvider(new CryptoProviderTest());
+        CarbonCoreDataHolder.getInstance().setCryptoService(defaultCryptoService);
     }
 
     @Test
@@ -118,6 +131,68 @@ public class CookieFunctionImplTest extends JsSequenceHandlerAbstractTest {
         context.addParameter(FrameworkConstants.RequestAttribute.HTTP_REQUEST, new TransientObjectWrapper(req));
         sequenceHandlerRunner.handle(req, resp, context, "carbon.super");
         verify(mockCookie).getValue();
+    }
+
+    @Test(dataProvider = "cookieValues")
+    public void testWithSpecialCharactersWithEncryption(String inputCookieValue) throws JsTestException {
+
+        boolean shouldEncrypt = true;
+        boolean shouldSign = false;
+        boolean shouldDecrypt = true;
+        System.setProperty("org.wso2.CipherTransformation", "RSA");
+        internalTestSetAndGetCookieValues(inputCookieValue, shouldEncrypt, shouldDecrypt, shouldSign);
+    }
+
+    @Test(dataProvider = "cookieValues")
+    public void testWithSpecialCharactersNoEncryption(String inputCookieValue) throws JsTestException {
+
+        boolean shouldEncrypt = false;
+        boolean shouldSign = false;
+        boolean shouldDecrypt = false;
+        internalTestSetAndGetCookieValues(inputCookieValue, shouldEncrypt, shouldDecrypt, shouldSign);
+    }
+
+    private void internalTestSetAndGetCookieValues(String inputCookieValue, boolean shouldEncrypt,
+                                                   boolean shouldDecrypt, boolean shouldSign) throws JsTestException {
+
+        CookieFunctionImpl cookieFunction = new CookieFunctionImpl();
+        String name = "test";
+
+        HttpServletResponse resp = sequenceHandlerRunner.createHttpServletResponse();
+        JsServletResponse jsServletResponse = new JsNashornServletResponse(new TransientObjectWrapper(resp));
+        Map<String, Object> setCookieParams = new HashMap<>();
+        setCookieParams.put(HTTPConstants.ENCRYPT, shouldEncrypt);
+        setCookieParams.put(HTTPConstants.SIGN, shouldSign);
+        // Set the Cookie value.
+        cookieFunction.setCookie(jsServletResponse, name, inputCookieValue, setCookieParams);
+
+        // Get the cookie value that added to the response when setCookie method value is called.
+        ArgumentCaptor<Cookie> argumentCaptor = ArgumentCaptor.forClass(Cookie.class);
+        verify(resp).addCookie(argumentCaptor.capture());
+        Cookie cookie = new Cookie(name,argumentCaptor.getValue().getValue());
+        Cookie mockCookie = Mockito.spy(cookie);
+        Cookie[] cookies = {mockCookie};
+
+        HttpServletRequest req = new MockServletRequestWithCookie(cookies);
+        JsServletRequest jsServletRequest = new JsNashornServletRequest(new TransientObjectWrapper(req));
+        Map<String, Object> getCookieParams = new HashMap<>();
+        getCookieParams.put(HTTPConstants.DECRYPT, shouldDecrypt);
+        // Get the cookie value
+        String value = cookieFunction.getCookieValue(jsServletRequest, name, getCookieParams );
+
+        Assert.assertEquals(value, inputCookieValue);
+    }
+
+    @DataProvider(name = "cookieValues")
+    public Object[][] getCookieValues() {
+
+        return new Object[][]{
+                {"Test"},
+                {"1234"},
+                {"Test1234"},
+                {"asgh@123&*()!@#$"},
+                {"{\"usr\" : \"" + "JohnDoe" + "\", \"str\" : \"" + "PRIMARY" + "\"}"}
+        };
     }
 
     private class MockServletRequestWithCookie extends JsSequenceHandlerRunner.MockServletRequest {

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/CryptoProviderTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/CryptoProviderTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.conditional.auth.functions.http;
+
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.api.InternalCryptoProvider;
+
+import java.security.Key;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+
+public class CryptoProviderTest implements InternalCryptoProvider {
+    private static final String ALGO = "AES";
+
+    /*
+     * Method to generate a secret key for AES algorithm with a given secret key.
+     */
+    private static Key generateKey(String secretKey) throws Exception
+    {
+        Key key = new SecretKeySpec(secretKey.getBytes(), ALGO);
+        return key;
+    }
+
+    @Override
+    public byte[] encrypt(byte[] cleartext, String algorithm, String javaSecurityAPIProvider) throws CryptoException {
+
+        try {
+            return this.encryptInternal(cleartext,"TheBestSecretKey");
+        } catch (Exception e) {
+            throw new CryptoException(e.getMessage());
+        }
+    }
+
+    @Override
+    public byte[] decrypt(byte[] ciphertext, String algorithm, String javaSecurityAPIProvider) throws CryptoException {
+
+        try {
+            return this.decryptInternal(ciphertext,"TheBestSecretKey");
+        } catch (Exception e) {
+            throw new CryptoException(e.getMessage());
+        }
+    }
+
+    @Override
+    public byte[] encrypt(byte[] cleartext, String algorithm, String javaSecurityAPIProvider,
+                          boolean returnSelfContainedCipherText) throws CryptoException {
+
+        try {
+            return this.encryptInternal(cleartext,"TheBestSecretKey");
+        } catch (Exception e) {
+            throw new CryptoException(e.getMessage());
+        }
+    }
+
+
+    private byte[] encryptInternal(byte[] data, String secretKey) throws Exception {
+
+        Key key = generateKey(secretKey);
+        Cipher c = Cipher.getInstance(ALGO);
+        c.init(Cipher.ENCRYPT_MODE, key);
+        byte[] encVal = c.doFinal(data);
+        return encVal;
+    }
+
+    private byte[] decryptInternal(byte[] encryptedData, String secretKey) throws Exception {
+
+        Key key = generateKey(secretKey);
+        Cipher c = Cipher.getInstance(ALGO);
+        c.init(Cipher.DECRYPT_MODE, key);
+        byte[] decValue = c.doFinal(encryptedData);
+        return decValue;
+    }
+}

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/CryptoProviderTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/CryptoProviderTest.java
@@ -83,7 +83,7 @@ public class CryptoProviderTest implements InternalCryptoProvider {
      * Method to generate a secret key for AES algorithm with a given secret key.
      */
     private static Key generateKey(String secretKey) throws Exception {
-        
+
         Key key = new SecretKeySpec(secretKey.getBytes(), ALGO);
         return key;
     }

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/CryptoProviderTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/CryptoProviderTest.java
@@ -82,8 +82,8 @@ public class CryptoProviderTest implements InternalCryptoProvider {
     /*
      * Method to generate a secret key for AES algorithm with a given secret key.
      */
-    private static Key generateKey(String secretKey) throws Exception
-    {
+    private static Key generateKey(String secretKey) throws Exception {
+        
         Key key = new SecretKeySpec(secretKey.getBytes(), ALGO);
         return key;
     }

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/CryptoProviderTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/CryptoProviderTest.java
@@ -29,15 +29,6 @@ import javax.crypto.spec.SecretKeySpec;
 public class CryptoProviderTest implements InternalCryptoProvider {
     private static final String ALGO = "AES";
 
-    /*
-     * Method to generate a secret key for AES algorithm with a given secret key.
-     */
-    private static Key generateKey(String secretKey) throws Exception
-    {
-        Key key = new SecretKeySpec(secretKey.getBytes(), ALGO);
-        return key;
-    }
-
     @Override
     public byte[] encrypt(byte[] cleartext, String algorithm, String javaSecurityAPIProvider) throws CryptoException {
 
@@ -86,5 +77,14 @@ public class CryptoProviderTest implements InternalCryptoProvider {
         c.init(Cipher.DECRYPT_MODE, key);
         byte[] decValue = c.doFinal(encryptedData);
         return decValue;
+    }
+
+    /*
+     * Method to generate a secret key for AES algorithm with a given secret key.
+     */
+    private static Key generateKey(String secretKey) throws Exception
+    {
+        Key key = new SecretKeySpec(secretKey.getBytes(), ALGO);
+        return key;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
             <dependency>
                 <groupId>org.wso2.carbon.crypto</groupId>
                 <artifactId>org.wso2.carbon.crypto.impl</artifactId>
-                <version>1.1.13</version>
+                <version>${carbon.crypto.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -486,6 +486,7 @@
         <org.testng.version>6.9.10</org.testng.version>
         <org.powermock.version>1.7.3</org.powermock.version>
         <com.h2database.version>1.2.140.wso2v3</com.h2database.version>
+        <carbon.crypto.version>1.1.13</carbon.crypto.version>
 
         <org.wso2.carbon.identity.conditional.auth.functions.version.range>[1.2,2.0)</org.wso2.carbon.identity.conditional.auth.functions.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,11 @@
                 <version>1.1.1</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.crypto</groupId>
+                <artifactId>org.wso2.carbon.crypto.impl</artifactId>
+                <version>1.1.13</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
### Purpose
> $subject

### Changes from the PR
> Remove the Base64 decode step , that used to decode a string that is not encode in `setCookie` method
> Remove the extra encode step from the `getCookieValue` method
> Implement new unit tests for test the functions with special characters with encryption


### Related issues
> https://github.com/wso2/product-is/issues/15134