### PR TITLE
Fix backward compatibility of encrypt and decrypt cookies

### DIFF
--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/CookieFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/CookieFunctionImpl.java
@@ -48,7 +48,7 @@ import javax.servlet.http.Cookie;
 public class CookieFunctionImpl implements SetCookieFunction, GetCookieFunction {
 
     private static final Log log = LogFactory.getLog(CookieFunctionImpl.class);
-    private static final String COOKIES_WITHOUT_SPECIAL_CHARACTERS = "cookiesWithoutSpecialCharacters";
+    private static final String KEEP_ADAPTIVE_SCRIPT_OLD_COOKIE = "keepAdaptiveScriptOldCookie";
 
     @Override
     public void setCookie(JsServletResponse response, String name, Object... params) {
@@ -78,7 +78,7 @@ public class CookieFunctionImpl implements SetCookieFunction, GetCookieFunction 
             }
             if (encrypt) {
                 try {
-                    if (Boolean.parseBoolean(System.getProperty(COOKIES_WITHOUT_SPECIAL_CHARACTERS))) {
+                    if (Boolean.parseBoolean(System.getProperty(KEEP_ADAPTIVE_SCRIPT_OLD_COOKIE))) {
                         value = CryptoUtil.getDefaultCryptoUtil().encryptAndBase64Encode(Base64.decode(value));
                     } else {
                         value = CryptoUtil.getDefaultCryptoUtil().encryptAndBase64Encode(
@@ -157,7 +157,7 @@ public class CookieFunctionImpl implements SetCookieFunction, GetCookieFunction 
                             .orElse(false);
                     if (decrypt) {
                         try {
-                            if (Boolean.parseBoolean(System.getProperty(COOKIES_WITHOUT_SPECIAL_CHARACTERS))) {
+                            if (Boolean.parseBoolean(System.getProperty(KEEP_ADAPTIVE_SCRIPT_OLD_COOKIE))) {
                                 valueString = Base64.encode(CryptoUtil.getDefaultCryptoUtil()
                                         .base64DecodeAndDecrypt(valueString));
                             } else {

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/CookieFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/CookieFunctionImpl.java
@@ -48,7 +48,7 @@ import javax.servlet.http.Cookie;
 public class CookieFunctionImpl implements SetCookieFunction, GetCookieFunction {
 
     private static final Log log = LogFactory.getLog(CookieFunctionImpl.class);
-    private static final String KEEP_ADAPTIVE_SCRIPT_OLD_COOKIE = "keepAdaptiveScriptOldCookie";
+    private static final String ENABLE_ADAPTIVE_SCRIPT_COOKIE_LEGACY_MODE = "enableAdaptiveScriptCookieLegacyMode";
 
     @Override
     public void setCookie(JsServletResponse response, String name, Object... params) {
@@ -78,7 +78,7 @@ public class CookieFunctionImpl implements SetCookieFunction, GetCookieFunction 
             }
             if (encrypt) {
                 try {
-                    if (Boolean.parseBoolean(System.getProperty(KEEP_ADAPTIVE_SCRIPT_OLD_COOKIE))) {
+                    if (Boolean.parseBoolean(System.getProperty(ENABLE_ADAPTIVE_SCRIPT_COOKIE_LEGACY_MODE))) {
                         value = CryptoUtil.getDefaultCryptoUtil().encryptAndBase64Encode(Base64.decode(value));
                     } else {
                         value = CryptoUtil.getDefaultCryptoUtil().encryptAndBase64Encode(
@@ -157,7 +157,7 @@ public class CookieFunctionImpl implements SetCookieFunction, GetCookieFunction 
                             .orElse(false);
                     if (decrypt) {
                         try {
-                            if (Boolean.parseBoolean(System.getProperty(KEEP_ADAPTIVE_SCRIPT_OLD_COOKIE))) {
+                            if (Boolean.parseBoolean(System.getProperty(ENABLE_ADAPTIVE_SCRIPT_COOKIE_LEGACY_MODE))) {
                                 valueString = Base64.encode(CryptoUtil.getDefaultCryptoUtil()
                                         .base64DecodeAndDecrypt(valueString));
                             } else {

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/CookieFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/CookieFunctionImpl.java
@@ -48,6 +48,7 @@ import javax.servlet.http.Cookie;
 public class CookieFunctionImpl implements SetCookieFunction, GetCookieFunction {
 
     private static final Log log = LogFactory.getLog(CookieFunctionImpl.class);
+    private static final String COOKIES_WITHOUT_SPECIAL_CHARACTERS = "cookiesWithoutSpecialCharacters";
 
     @Override
     public void setCookie(JsServletResponse response, String name, Object... params) {
@@ -77,8 +78,12 @@ public class CookieFunctionImpl implements SetCookieFunction, GetCookieFunction 
             }
             if (encrypt) {
                 try {
-                    value = CryptoUtil.getDefaultCryptoUtil().encryptAndBase64Encode(
-                            value.getBytes(StandardCharsets.UTF_8));
+                    if (Boolean.parseBoolean(System.getProperty(COOKIES_WITHOUT_SPECIAL_CHARACTERS))) {
+                        value = CryptoUtil.getDefaultCryptoUtil().encryptAndBase64Encode(Base64.decode(value));
+                    } else {
+                        value = CryptoUtil.getDefaultCryptoUtil().encryptAndBase64Encode(
+                                value.getBytes(StandardCharsets.UTF_8));
+                    }
                 } catch (CryptoException e) {
                     log.error("Error occurred when encrypting the cookie value.", e);
                     return;
@@ -152,8 +157,13 @@ public class CookieFunctionImpl implements SetCookieFunction, GetCookieFunction 
                             .orElse(false);
                     if (decrypt) {
                         try {
-                            valueString = new String(CryptoUtil.getDefaultCryptoUtil()
-                                    .base64DecodeAndDecrypt(valueString), StandardCharsets.UTF_8);
+                            if (Boolean.parseBoolean(System.getProperty(COOKIES_WITHOUT_SPECIAL_CHARACTERS))) {
+                                valueString = Base64.encode(CryptoUtil.getDefaultCryptoUtil()
+                                        .base64DecodeAndDecrypt(valueString));
+                            } else {
+                                valueString = new String(CryptoUtil.getDefaultCryptoUtil()
+                                        .base64DecodeAndDecrypt(valueString), StandardCharsets.UTF_8);
+                            }
                         } catch (CryptoException e) {
                             log.error("Error occurred when decrypting the cookie value.", e);
                             return null;


### PR DESCRIPTION
## Purpose
-  $subject
- This fix is done for keep backward compatible of encrypt and decrypt cookie values after migration.

- Can use below configuration to deployment.toml file and keep the cookie values valid after the migration also.
```
[system.parameter]
enableAdaptiveScriptCookieLegacyMode=true
```


### Related issue 
https://github.com/wso2/product-is/issues/15134
