### PR TITLE
Resolve user id claim URI for account linking

### DIFF
--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/pom.xml
@@ -148,6 +148,7 @@
                             org.wso2.carbon.identity.application.authentication.framework.dao.impl,
                             org.wso2.carbon.identity.application.authentication.framework.dao,
                             org.wso2.carbon.identity.base.*,
+                            org.wso2.carbon.identity.claim.*,
                             org.wso2.carbon.identity.core.util.*,
                             org.wso2.carbon.identity.core.model.*,
                             org.wso2.carbon.identity.user.profile.mgt,

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/GetAssociatedLocalUserFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/GetAssociatedLocalUserFunctionImpl.java
@@ -51,11 +51,15 @@ public class GetAssociatedLocalUserFunctionImpl implements GetAssociatedLocalUse
         String externalSubject = null;
         try {
             String userIdClaimURI = Utils.getUserIdClaimURI(externalIdpName, tenantDomain);
+            if (StringUtils.isEmpty(userIdClaimURI)) {
+                userIdClaimURI = Utils.resolveUserIDClaimURIFromMapping(externalIdpName, tenantDomain);
+            }
             if (StringUtils.isNotEmpty(userIdClaimURI) &&
                     MapUtils.isNotEmpty(federatedUser.getWrapped().getUserAttributes())) {
+                String finalUserIdClaimURI = userIdClaimURI;
                 externalSubject = federatedUser.getWrapped().getUserAttributes().entrySet().stream().filter(
                         userAttribute -> userAttribute.getKey().getRemoteClaim().getClaimUri()
-                                .equals(userIdClaimURI))
+                                .equals(finalUserIdClaimURI))
                         .map(Map.Entry::getValue)
                         .findFirst()
                         .orElse(null);

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/GetAssociatedLocalUserFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/GetAssociatedLocalUserFunctionImpl.java
@@ -52,7 +52,7 @@ public class GetAssociatedLocalUserFunctionImpl implements GetAssociatedLocalUse
         try {
             String userIdClaimURI = Utils.getUserIdClaimURI(externalIdpName, tenantDomain);
             if (StringUtils.isEmpty(userIdClaimURI)) {
-                userIdClaimURI = Utils.resolveUserIDClaimURIFromMapping(externalIdpName, tenantDomain);
+                userIdClaimURI = Utils.resolveUsername(externalIdpName, tenantDomain);
             }
             if (StringUtils.isNotEmpty(userIdClaimURI) &&
                     MapUtils.isNotEmpty(federatedUser.getWrapped().getUserAttributes())) {

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/SetAccountAssociationToLocalUserImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/SetAccountAssociationToLocalUserImpl.java
@@ -50,11 +50,15 @@ public class SetAccountAssociationToLocalUserImpl implements SetAccountAssociati
                     }
                     federatedIdpName = federatedUser.getWrapped().getFederatedIdPName();
                     String userIdClaimURI = Utils.getUserIdClaimURI(federatedIdpName, tenantDomain);
+                    if (StringUtils.isEmpty(userIdClaimURI)) {
+                        userIdClaimURI = Utils.resolveUserIDClaimURIFromMapping(federatedIdpName, tenantDomain);
+                    }
                     String externalSubject;
                     if (StringUtils.isNotEmpty(userIdClaimURI)) {
+                        String finalUserIdClaimURI = userIdClaimURI;
                         externalSubject = federatedUser.getWrapped().getUserAttributes().entrySet().stream().filter(
                                 userAttribute -> userAttribute.getKey().getRemoteClaim().getClaimUri()
-                                        .equals(userIdClaimURI))
+                                        .equals(finalUserIdClaimURI))
                                 .map(Map.Entry::getValue)
                                 .findFirst()
                                 .orElse(null);

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/SetAccountAssociationToLocalUserImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/SetAccountAssociationToLocalUserImpl.java
@@ -51,7 +51,7 @@ public class SetAccountAssociationToLocalUserImpl implements SetAccountAssociati
                     federatedIdpName = federatedUser.getWrapped().getFederatedIdPName();
                     String userIdClaimURI = Utils.getUserIdClaimURI(federatedIdpName, tenantDomain);
                     if (StringUtils.isEmpty(userIdClaimURI)) {
-                        userIdClaimURI = Utils.resolveUserIDClaimURIFromMapping(federatedIdpName, tenantDomain);
+                        userIdClaimURI = Utils.resolveUsername(federatedIdpName, tenantDomain);
                     }
                     String externalSubject;
                     if (StringUtils.isNotEmpty(userIdClaimURI)) {

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/Utils.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/Utils.java
@@ -144,10 +144,10 @@ public class Utils {
      *
      * @param federatedIdpName federated IdP name.
      * @param tenantDomain  tenant domain.
-     * @return userIDcClaimURI.
+     * @return user ID ClaimURI.
      * @throws IdentityProviderManagementException If an error occurred in resolving userID claim URI.
      */
-    public static String resolveUserIDClaimURIFromMapping(String federatedIdpName, String tenantDomain)
+    public static String resolveUsername(String federatedIdpName, String tenantDomain)
             throws IdentityProviderManagementException {
 
         List<ExternalClaim> defaultClaims = getDefaultOIDCDialectClaims(tenantDomain);
@@ -183,7 +183,7 @@ public class Utils {
      *
      * @param federatedIdpName Name of the Identity provider.
      * @param tenantDomain Tenant domain.
-     * @return claimMappings
+     * @return claimMappings.
      * @throws IdentityProviderManagementException If an error occurred in getting claim mapping.
      */
     private static ClaimMapping[] getIdPClaimMapping(String federatedIdpName, String tenantDomain)

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/internal/UserFunctionsServiceComponent.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/internal/UserFunctionsServiceComponent.java
@@ -29,6 +29,7 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.application.authentication.framework.JsFunctionRegistry;
 import org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.conditional.auth.functions.user.AssignUserRolesFunction;
 import org.wso2.carbon.identity.conditional.auth.functions.user.AssignUserRolesFunctionImpl;
 import org.wso2.carbon.identity.conditional.auth.functions.user.CheckSessionExistenceFunctionImpl;
@@ -235,6 +236,24 @@ public class UserFunctionsServiceComponent {
             LOG.debug("IdpManager service is unset in the conditional authentication user functions bundle");
         }
         UserFunctionsServiceHolder.getInstance().setIdentityProviderManagementService(null);
+    }
+
+    @Reference(
+            name = "claim.meta.mgt.service",
+            service = ClaimMetadataManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetClaimMetaMgtService"
+    )
+    protected void setClaimMetaMgtService(ClaimMetadataManagementService claimMetaMgtService) {
+
+        UserFunctionsServiceHolder.getInstance().setClaimMetadataManagementService(
+                claimMetaMgtService);
+    }
+
+    protected void unsetClaimMetaMgtService(ClaimMetadataManagementService claimMetaMgtService) {
+
+        UserFunctionsServiceHolder.getInstance().setClaimMetadataManagementService(null);
     }
 
 }

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/internal/UserFunctionsServiceHolder.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/internal/UserFunctionsServiceHolder.java
@@ -99,11 +99,21 @@ public class UserFunctionsServiceHolder {
         this.jsFunctionRegistry = jsFunctionRegistry;
     }
 
+    /**
+     * Method to get the Claim Metadata Management Service.
+     *
+     * @return claimMetadataManagementService.
+     */
     public ClaimMetadataManagementService getClaimMetadataManagementService() {
 
         return claimMetadataManagementService;
     }
 
+    /**
+     * Method to set the Claim Metadata Management Service.
+     *
+     * @param claimMetadataManagementService Claim Metadata Management Service.
+     */
     public void setClaimMetadataManagementService(
             ClaimMetadataManagementService claimMetadataManagementService) {
 

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/internal/UserFunctionsServiceHolder.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/internal/UserFunctionsServiceHolder.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.conditional.auth.functions.user.internal;
 
 import org.wso2.carbon.identity.application.authentication.framework.JsFunctionRegistry;
 import org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementService;
 import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
@@ -34,6 +35,8 @@ public class UserFunctionsServiceHolder {
     private UserSessionManagementService userSessionManagementService;
     private IdpManager identityProviderManagementService;
     private JsFunctionRegistry jsFunctionRegistry;
+    private ClaimMetadataManagementService claimMetadataManagementService;
+
 
     private UserFunctionsServiceHolder() {
 
@@ -94,5 +97,16 @@ public class UserFunctionsServiceHolder {
     public void setJsFunctionRegistry(JsFunctionRegistry jsFunctionRegistry) {
 
         this.jsFunctionRegistry = jsFunctionRegistry;
+    }
+
+    public ClaimMetadataManagementService getClaimMetadataManagementService() {
+
+        return claimMetadataManagementService;
+    }
+
+    public void setClaimMetadataManagementService(
+            ClaimMetadataManagementService claimMetadataManagementService) {
+
+        this.claimMetadataManagementService = claimMetadataManagementService;
     }
 }


### PR DESCRIPTION
## Purpose
> The userID claim URI is null as the IDP claim mapping are removed. Therefore subject identifier is used for account linking which cases issues in account linking process.

**Related issue**
https://github.com/wso2-enterprise/asgardeo-product/issues/14996