### PR TITLE
Fix issues in resolving userIdClaimUri

### DIFF
--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/Utils.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/Utils.java
@@ -134,6 +134,10 @@ public class Utils {
         if (claimMappings == null || claimMappings.length < 1) {
             return null;
         }
+        userIdClaimURI = claimConfigs.getUserClaimURI();
+        if (userIdClaimURI != null) {
+            return userIdClaimURI;
+        }
         ClaimMapping userNameClaimMapping = Arrays.stream(claimMappings).filter(claimMapping ->
                 StringUtils.equals(USERNAME_LOCAL_CLAIM, claimMapping.getLocalClaim().getClaimUri()))
                 .findFirst()
@@ -141,7 +145,6 @@ public class Utils {
         if (userNameClaimMapping != null) {
             userIdClaimURI = userNameClaimMapping.getRemoteClaim().getClaimUri();
         }
-        userIdClaimURI = claimConfigs.getUserClaimURI();
         return userIdClaimURI;
     }
 

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/Utils.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/Utils.java
@@ -141,6 +141,7 @@ public class Utils {
         if (userNameClaimMapping != null) {
             userIdClaimURI = userNameClaimMapping.getRemoteClaim().getClaimUri();
         }
+        userIdClaimURI = claimConfigs.getUserClaimURI();
         return userIdClaimURI;
     }
 


### PR DESCRIPTION
## Purpose
> When doing the federated association, it checks whether there is an idp claim mapped to the username local claim. If not it picks the idp subject identifier as the external User ID. As a result, there is no proper association created and it prompts for the account linking every time. Therefore, we try to get it directly from the user ID claim uri configured for the IDP.
