### PR TITLE
Add http header capability to httpPost and httpGet methods

### DIFF
--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/pom.xml
@@ -133,6 +133,7 @@
                         </Export-Package>
                         <Import-Package>
                             javax.servlet.*; version="${imp.pkg.version.javax.servlet}",
+                            org.apache.commons.collections,
                             org.apache.commons.io,
                             org.apache.commons.lang,
                             org.apache.commons.logging,
@@ -140,10 +141,12 @@
                             org.apache.http.impl,
                             org.apache.http.util,
                             org.apache.http.client,
+                            org.apache.http.client.entity,
                             org.apache.http.client.methods,
                             org.apache.http.client.config,
                             org.apache.http.impl.client,
                             org.apache.http.conn,
+                            org.apache.http.message,
                             org.json.simple,
                             org.json.simple.parser,
                             org.apache.http,

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPGetWithHeadersFunction.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPGetWithHeadersFunction.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.conditional.auth.functions.http;
 
+import org.wso2.carbon.identity.event.IdentityEventException;
+
 import java.util.Map;
 
 /**

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPGetWithHeadersFunction.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPGetWithHeadersFunction.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.conditional.auth.functions.http;
+
+import java.util.Map;
+
+/**
+ * Function to call http endpoints. Function will send get with headers to the given endpoint reference.
+ */
+@FunctionalInterface
+public interface HTTPGetWithHeadersFunction {
+
+    /**
+     *  POST data to the given endpoint.
+     *
+     * @param epUrl Endpoint url.
+     * @param headers headers.
+     * @param eventHandlers event handlers.
+     */
+    void httpGetWithHeaders(String epUrl, Map<String, String> headers, Map<String, Object> eventHandlers);
+}

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPGetWithHeadersFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPGetWithHeadersFunctionImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.conditional.auth.functions.http;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.client.methods.HttpGet;
+
+import java.util.Map;
+
+import static org.apache.http.HttpHeaders.ACCEPT;
+
+/**
+ * Implementation of the {@link HTTPGetFunction}
+ */
+public class HTTPGetWithHeadersFunctionImpl extends AbstractHTTPFunction implements HTTPGetWithHeadersFunction {
+
+    private static final Log LOG = LogFactory.getLog(HTTPGetWithHeadersFunctionImpl.class);
+
+    public HTTPGetWithHeadersFunctionImpl() {
+
+        super();
+    }
+
+    @Override
+    public void httpGetWithHeaders(String epUrl, Map<String, String> headers, Map<String, Object> eventHandlers) {
+
+        HttpGet request = new HttpGet(epUrl);
+        request.setHeader(ACCEPT, TYPE_APPLICATION_JSON);
+
+        headers.entrySet().stream()
+                .filter(entry -> entry.getKey() != null)
+                .forEach(entry -> request.setHeader(entry.getKey(), entry.getValue()));
+
+        executeHttpMethod(request, eventHandlers);
+    }
+
+}

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPGetWithHeadersFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPGetWithHeadersFunctionImpl.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.client.methods.HttpGet;
+import org.wso2.carbon.identity.event.IdentityEventException;
 
 import java.util.Map;
 
@@ -51,5 +52,4 @@ public class HTTPGetWithHeadersFunctionImpl extends AbstractHTTPFunction impleme
 
         executeHttpMethod(request, eventHandlers);
     }
-
 }

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPGetWithHeadersFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPGetWithHeadersFunctionImpl.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.http.client.methods.HttpGet;
 import org.wso2.carbon.identity.event.IdentityEventException;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.http.HttpHeaders.ACCEPT;
@@ -44,8 +45,11 @@ public class HTTPGetWithHeadersFunctionImpl extends AbstractHTTPFunction impleme
     public void httpGetWithHeaders(String epUrl, Map<String, String> headers, Map<String, Object> eventHandlers) {
 
         HttpGet request = new HttpGet(epUrl);
-        request.setHeader(ACCEPT, TYPE_APPLICATION_JSON);
 
+        if (headers == null) {
+            headers = new HashMap<>();
+        }
+        headers.putIfAbsent(ACCEPT, TYPE_APPLICATION_JSON);
         headers.entrySet().stream()
                 .filter(entry -> entry.getKey() != null)
                 .forEach(entry -> request.setHeader(entry.getKey(), entry.getValue()));

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPPostWithHeadersFunction.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPPostWithHeadersFunction.java
@@ -18,32 +18,22 @@
 
 package org.wso2.carbon.identity.conditional.auth.functions.http;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.apache.http.client.methods.HttpGet;
-
 import java.util.Map;
 
-import static org.apache.http.HttpHeaders.ACCEPT;
-
 /**
- * Implementation of the {@link HTTPGetFunction}
+ * Function to call http endpoints. Function will post to the given endpoint reference with payload data as a json.
  */
-public class HTTPGetFunctionImpl extends AbstractHTTPFunction implements HTTPGetFunction {
+@FunctionalInterface
+public interface HTTPPostWithHeadersFunction {
 
-    private static final Log LOG = LogFactory.getLog(HTTPGetFunctionImpl.class);
-
-    public HTTPGetFunctionImpl() {
-
-        super();
-    }
-
-    @Override
-    public void httpGet(String epUrl, Map<String, Object> eventHandlers) {
-
-        HttpGet request = new HttpGet(epUrl);
-        LOG.error("httpGet: " + epUrl);
-        request.setHeader(ACCEPT, TYPE_APPLICATION_JSON);
-        executeHttpMethod(request, eventHandlers);
-    }
+    /**
+     *  POST data to the given endpoint.
+     *
+     * @param epUrl Endpoint url.
+     * @param payloadData payload data.
+     * @param headers headers.
+     * @param eventHandlers event handlers.
+     */
+    void httpPostWithHeaders(String epUrl, Map<String, Object> payloadData, Map<String, String> headers,
+                  Map<String, Object> eventHandlers);
 }

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPPostWithHeadersFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPPostWithHeadersFunctionImpl.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.conditional.auth.functions.http;
+
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.NameValuePair;
+import org.json.simple.JSONObject;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.http.HttpHeaders.ACCEPT;
+import static org.apache.http.HttpHeaders.CONTENT_TYPE;
+
+
+/**
+ * Implementation of the {@link HTTPPostFunction}
+ */
+public class HTTPPostWithHeadersFunctionImpl extends AbstractHTTPFunction implements HTTPPostWithHeadersFunction {
+
+    private static final Log LOG = LogFactory.getLog(HTTPPostWithHeadersFunctionImpl.class);
+
+    public HTTPPostWithHeadersFunctionImpl() {
+
+       super();
+    }
+
+    @Override
+    public void httpPostWithHeaders(String epUrl, Map<String, Object> payloadData, Map<String, String> headers, Map<String, Object> eventHandlers) {
+
+        HttpPost request = new HttpPost(epUrl);
+
+        if (headers == null) {
+            headers = new HashMap<>();
+        }
+
+        headers.putIfAbsent(ACCEPT, TYPE_APPLICATION_JSON);
+        headers.putIfAbsent(CONTENT_TYPE, TYPE_APPLICATION_JSON);
+        headers.entrySet().stream()
+                .filter(entry -> entry.getKey() != null)
+                .forEach(entry -> request.setHeader(entry.getKey(), entry.getValue()));
+
+        if (MapUtils.isNotEmpty(payloadData)) {
+            //For the header "Content-Type : application/x-www-form-urlencoded" request body data is set to
+            // UrlEncodedFormEntity format. For the other cases request body data is set to StringEntity format.
+            if (TYPE_APPLICATION_FORM_URLENCODED.equals(headers.get(CONTENT_TYPE))) {
+                List<NameValuePair> entities = new ArrayList<>();
+                for (Map.Entry<String, Object> dataElements : payloadData.entrySet()) {
+                    if (!StringUtils.isEmpty(dataElements.getKey())) {
+                        String value = (dataElements.getValue() != null) ? dataElements.getValue().toString() : null;
+                        entities.add(new BasicNameValuePair(dataElements.getKey(), value));
+                    }
+                }
+                request.setEntity(new UrlEncodedFormEntity(entities, StandardCharsets.UTF_8));
+            } else {
+                JSONObject jsonObject = new JSONObject();
+                for (Map.Entry<String, Object> dataElements : payloadData.entrySet()) {
+                    if (!StringUtils.isEmpty(dataElements.getKey())) {
+                        jsonObject.put(dataElements.getKey(), dataElements.getValue());
+                    }
+                }
+                request.setEntity(new StringEntity(jsonObject.toJSONString(), StandardCharsets.UTF_8));
+            }
+        }
+
+        executeHttpMethod(request, eventHandlers);
+    }
+}

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/internal/HTTPFunctionsServiceComponent.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/http/internal/HTTPFunctionsServiceComponent.java
@@ -31,8 +31,12 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.application.authentication.framework.JsFunctionRegistry;
 import org.wso2.carbon.identity.conditional.auth.functions.http.HTTPGetFunction;
 import org.wso2.carbon.identity.conditional.auth.functions.http.HTTPGetFunctionImpl;
+import org.wso2.carbon.identity.conditional.auth.functions.http.HTTPGetWithHeadersFunction;
+import org.wso2.carbon.identity.conditional.auth.functions.http.HTTPGetWithHeadersFunctionImpl;
 import org.wso2.carbon.identity.conditional.auth.functions.http.HTTPPostFunction;
 import org.wso2.carbon.identity.conditional.auth.functions.http.HTTPPostFunctionImpl;
+import org.wso2.carbon.identity.conditional.auth.functions.http.HTTPPostWithHeadersFunction;
+import org.wso2.carbon.identity.conditional.auth.functions.http.HTTPPostWithHeadersFunctionImpl;
 import org.wso2.carbon.identity.conditional.auth.functions.http.CookieFunctionImpl;
 import org.wso2.carbon.identity.conditional.auth.functions.http.GetCookieFunction;
 import org.wso2.carbon.identity.conditional.auth.functions.http.SetCookieFunction;
@@ -51,7 +55,9 @@ public class HTTPFunctionsServiceComponent {
     private static final Log LOG = LogFactory.getLog(HTTPFunctionsServiceComponent.class);
 
     public static final String FUNC_HTTP_POST = "httpPost";
+    public static final String FUNC_HTTP_POST_WITH_HEADERS = "httpPostWithHeaders";
     public static final String FUNC_HTTP_GET = "httpGet";
+    public static final String FUNC_HTTP_GET_WITH_HEADERS = "httpGetWithHeaders";
     public static final String FUNC_SET_COOKIE = "setCookie";
     public static final String FUNC_GET_COOKIE_VALUE = "getCookieValue";
 
@@ -68,8 +74,16 @@ public class HTTPFunctionsServiceComponent {
         HTTPPostFunction httpPost = new HTTPPostFunctionImpl();
         jsFunctionRegistry.register(JsFunctionRegistry.Subsystem.SEQUENCE_HANDLER, FUNC_HTTP_POST, httpPost);
 
+        HTTPPostWithHeadersFunction httpPostWithHeaders = new HTTPPostWithHeadersFunctionImpl();
+        jsFunctionRegistry.register(JsFunctionRegistry.Subsystem.SEQUENCE_HANDLER, FUNC_HTTP_POST_WITH_HEADERS,
+                httpPostWithHeaders);
+
         HTTPGetFunction httpGet = new HTTPGetFunctionImpl();
         jsFunctionRegistry.register(JsFunctionRegistry.Subsystem.SEQUENCE_HANDLER, FUNC_HTTP_GET, httpGet);
+
+        HTTPGetWithHeadersFunction httpGetWithHeaders = new HTTPGetWithHeadersFunctionImpl();
+        jsFunctionRegistry.register(JsFunctionRegistry.Subsystem.SEQUENCE_HANDLER, FUNC_HTTP_GET_WITH_HEADERS,
+                httpGetWithHeaders);
     }
 
     @Deactivate
@@ -80,6 +94,9 @@ public class HTTPFunctionsServiceComponent {
             jsFunctionRegistry.deRegister(JsFunctionRegistry.Subsystem.SEQUENCE_HANDLER, FUNC_SET_COOKIE);
             jsFunctionRegistry.deRegister(JsFunctionRegistry.Subsystem.SEQUENCE_HANDLER, FUNC_GET_COOKIE_VALUE);
             jsFunctionRegistry.deRegister(JsFunctionRegistry.Subsystem.SEQUENCE_HANDLER, FUNC_HTTP_POST);
+            jsFunctionRegistry.deRegister(JsFunctionRegistry.Subsystem.SEQUENCE_HANDLER, FUNC_HTTP_GET);
+            jsFunctionRegistry.deRegister(JsFunctionRegistry.Subsystem.SEQUENCE_HANDLER, FUNC_HTTP_GET_WITH_HEADERS);
+            jsFunctionRegistry.deRegister(JsFunctionRegistry.Subsystem.SEQUENCE_HANDLER, FUNC_HTTP_POST_WITH_HEADERS);
         }
     }
 

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPGetWithHeadersFunctionImplTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPGetWithHeadersFunctionImplTest.java
@@ -1,0 +1,174 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.carbon.identity.conditional.auth.functions.http;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.dao.impl.CacheBackedLongWaitStatusDAO;
+import org.wso2.carbon.identity.application.authentication.framework.dao.impl.LongWaitStatusDAOImpl;
+import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
+import org.wso2.carbon.identity.application.authentication.framework.store.LongWaitStatusStoreService;
+import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthenticationConfig;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.common.model.script.AuthenticationScriptConfig;
+import org.wso2.carbon.identity.common.testng.*;
+import org.wso2.carbon.identity.conditional.auth.functions.common.utils.ConfigProvider;
+import org.wso2.carbon.identity.conditional.auth.functions.test.utils.sequence.JsSequenceHandlerAbstractTest;
+import org.wso2.carbon.identity.conditional.auth.functions.test.utils.sequence.JsTestException;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.reset;
+import static org.testng.Assert.assertEquals;
+
+@WithCarbonHome
+@WithMicroService
+@WithH2Database(files = {"dbscripts/h2_http.sql"})
+@WithRealmService(injectToSingletons = {IdentityTenantUtil.class, FrameworkServiceDataHolder.class})
+@Path("/")
+public class HTTPGetWithHeadersFunctionImplTest extends JsSequenceHandlerAbstractTest {
+
+    private static final String TEST_SP_CONFIG = "http-get-with-headers-test-sp.xml";
+    private static final String JS_FUNCTION_NAME = "httpGetWithHeaders";
+    private static final String TENANT_DOMAIN = "carbon.super";
+    private static final String STATUS = "status";
+    private static final String SUCCESS = "SUCCESS";
+    private static final String FAILED = "FAILED";
+    private static final String ALLOWED_DOMAIN = "abc";
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String AUTHORIZATION_HEADER_VALUE = "Bearer your-token";
+
+    @InjectMicroservicePort
+    private int microServicePort;
+
+    @BeforeClass
+    protected void initClass() throws Exception {
+
+        super.setUp();
+        LongWaitStatusDAOImpl daoImpl = new LongWaitStatusDAOImpl();
+        CacheBackedLongWaitStatusDAO cacheBackedDao = new CacheBackedLongWaitStatusDAO(daoImpl);
+        int connectionTimeout = 5000;
+        LongWaitStatusStoreService longWaitStatusStoreService =
+                new LongWaitStatusStoreService(cacheBackedDao, connectionTimeout);
+        FrameworkServiceDataHolder.getInstance().setLongWaitStatusStoreService(longWaitStatusStoreService);
+        sequenceHandlerRunner.registerJsFunction(JS_FUNCTION_NAME, new HTTPGetWithHeadersFunctionImpl());
+    }
+
+    @AfterClass
+    protected void tearDown() {
+
+        unsetAllowedDomains();
+    }
+
+    /**
+     * Tests if the
+     * @throws JsTestException
+     */
+    @Test
+    public void testHttpGetWithHeadersMethod() throws JsTestException {
+
+        String requestUrl = getRequestUrl();
+        String result = executeHttpGetFunction(requestUrl);
+
+        assertEquals(result, SUCCESS, "The http get request was not successful. Result from request: " + result);
+    }
+
+    @Test(dependsOnMethods = {"testHttpGetWithHeadersMethod"})
+    public void testHttpGetWithHeadersMethodUrlValidation() throws JsTestException, NoSuchFieldException, IllegalAccessException {
+
+        setAllowedDomain(ALLOWED_DOMAIN);
+        String requestUrl = getRequestUrl();
+        String result = executeHttpGetFunction(requestUrl);
+
+        assertEquals(result, FAILED, "The http get request should fail but it was successful. Result from request: "
+                + result);
+    }
+
+    private void setAllowedDomain(String domain) {
+
+        ConfigProvider.getInstance().getAllowedDomainsForHttpFunctions().add(domain);
+    }
+
+    private void unsetAllowedDomains() {
+
+        ConfigProvider.getInstance().getAllowedDomainsForHttpFunctions().clear();
+    }
+
+    private String getRequestUrl() {
+
+        return "http://localhost:" + microServicePort + "/dummy-get-with-headers";
+    }
+
+    private String executeHttpGetFunction(String requestUrl) throws JsTestException {
+
+        ServiceProvider sp = sequenceHandlerRunner.loadServiceProviderFromResource(TEST_SP_CONFIG, this);
+        updateSPAuthScriptRequestUrl(sp, requestUrl);
+
+        AuthenticationContext context = sequenceHandlerRunner.createAuthenticationContext(sp);
+        SequenceConfig sequenceConfig = sequenceHandlerRunner.getSequenceConfig(context, sp);
+        context.setSequenceConfig(sequenceConfig);
+        context.initializeAnalyticsData();
+
+        HttpServletRequest req = sequenceHandlerRunner.createHttpServletRequest();
+        HttpServletResponse resp = sequenceHandlerRunner.createHttpServletResponse();
+
+        sequenceHandlerRunner.handle(req, resp, context, TENANT_DOMAIN);
+
+        // Using selected acr as a mechanism to relay the
+        // auth script execution state back to the context.
+        return context.getSelectedAcr();
+    }
+
+    private void updateSPAuthScriptRequestUrl(ServiceProvider sp, String url) {
+
+        LocalAndOutboundAuthenticationConfig localAndOutboundAuthenticationConfig =
+                sp.getLocalAndOutBoundAuthenticationConfig();
+        AuthenticationScriptConfig authenticationScriptConfig = localAndOutboundAuthenticationConfig
+                .getAuthenticationScriptConfig();
+        String script = authenticationScriptConfig.getContent();
+        authenticationScriptConfig.setContent(String.format(script, url));
+        localAndOutboundAuthenticationConfig.setAuthenticationScriptConfig(authenticationScriptConfig);
+        sp.setLocalAndOutBoundAuthenticationConfig(localAndOutboundAuthenticationConfig);
+    }
+
+    @GET
+    @Path("/dummy-get-with-headers")
+    @Produces("application/json")
+    public Map<String, String> dummyGetWithHeaders(@HeaderParam(AUTHORIZATION) String authorization) {
+
+        Map<String, String> response = new HashMap<>();
+        if (authorization != null && authorization.equals(AUTHORIZATION_HEADER_VALUE)) {
+            response.put(STATUS, SUCCESS);
+        } else {
+            response.put(STATUS, FAILED);
+        }
+        return response;
+    }
+}

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/resources/org/wso2/carbon/identity/conditional/auth/functions/http/http-get-with-headers-test-sp.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/resources/org/wso2/carbon/identity/conditional/auth/functions/http/http-get-with-headers-test-sp.xml
@@ -1,0 +1,75 @@
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org).
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<ServiceProvider>
+    <ApplicationID>1</ApplicationID>
+    <ApplicationName>default</ApplicationName>
+    <Description>Default Service Provider</Description>
+    <InboundAuthenticationConfig>
+        <InboundAuthenticationRequestConfigs>
+            <InboundAuthenticationRequestConfig>
+                <InboundAuthKey>default</InboundAuthKey>
+                <InboundAuthType></InboundAuthType>
+                <Properties></Properties>
+            </InboundAuthenticationRequestConfig>
+        </InboundAuthenticationRequestConfigs>
+    </InboundAuthenticationConfig>
+    <LocalAndOutBoundAuthenticationConfig>
+        <AuthenticationSteps>
+            <AuthenticationStep>
+                <StepOrder>1</StepOrder>
+                <LocalAuthenticatorConfigs>
+                    <LocalAuthenticatorConfig>
+                        <Name>BasicMockAuthenticator</Name>
+                        <DisplayName>basicauth</DisplayName>
+                        <IsEnabled>true</IsEnabled>
+                    </LocalAuthenticatorConfig>
+                </LocalAuthenticatorConfigs>
+                <SubjectStep>true</SubjectStep>
+                <AttributeStep>true</AttributeStep>
+            </AuthenticationStep>
+        </AuthenticationSteps>
+        <AuthenticationScript type="application/javascript" enabled="true"><![CDATA[
+
+function onLoginRequest(context) {
+    httpGetWithHeaders('%s',
+                {
+                    "Authorization": "Bearer your-token"
+                }, {
+                onSuccess : function(context, data) {
+                    Log.info('httpGet call success');
+                    context.selectedAcr = data.status;
+                    executeStep(1);
+                }, onFail : function(context, data) {
+                    Log.info('httpGet call failed');
+                    context.selectedAcr = 'FAILED';
+                    executeStep(1);
+                }
+            });
+}
+
+]]></AuthenticationScript>
+        <AuthenticationType>flow</AuthenticationType>
+    </LocalAndOutBoundAuthenticationConfig>
+    <RequestPathAuthenticatorConfigs></RequestPathAuthenticatorConfigs>
+    <InboundProvisioningConfig></InboundProvisioningConfig>
+    <OutboundProvisioningConfig></OutboundProvisioningConfig>
+    <ClaimConfig>
+        <AlwaysSendMappedLocalSubjectId>true</AlwaysSendMappedLocalSubjectId>
+    </ClaimConfig>
+    <PermissionAndRoleConfig></PermissionAndRoleConfig>
+</ServiceProvider>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/resources/org/wso2/carbon/identity/conditional/auth/functions/http/http-post-with-headers-test-sp.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/resources/org/wso2/carbon/identity/conditional/auth/functions/http/http-post-with-headers-test-sp.xml
@@ -1,0 +1,75 @@
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org).
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<ServiceProvider>
+    <ApplicationID>1</ApplicationID>
+    <ApplicationName>default</ApplicationName>
+    <Description>Default Service Provider</Description>
+    <InboundAuthenticationConfig>
+        <InboundAuthenticationRequestConfigs>
+            <InboundAuthenticationRequestConfig>
+                <InboundAuthKey>default</InboundAuthKey>
+                <InboundAuthType></InboundAuthType>
+                <Properties></Properties>
+            </InboundAuthenticationRequestConfig>
+        </InboundAuthenticationRequestConfigs>
+    </InboundAuthenticationConfig>
+    <LocalAndOutBoundAuthenticationConfig>
+        <AuthenticationSteps>
+            <AuthenticationStep>
+                <StepOrder>1</StepOrder>
+                <LocalAuthenticatorConfigs>
+                    <LocalAuthenticatorConfig>
+                        <Name>BasicMockAuthenticator</Name>
+                        <DisplayName>basicauth</DisplayName>
+                        <IsEnabled>true</IsEnabled>
+                    </LocalAuthenticatorConfig>
+                </LocalAuthenticatorConfigs>
+                <SubjectStep>true</SubjectStep>
+                <AttributeStep>true</AttributeStep>
+            </AuthenticationStep>
+        </AuthenticationSteps>
+        <AuthenticationScript type="application/javascript" enabled="true"><![CDATA[
+
+function onLoginRequest(context) {
+    httpPostWithHeaders('%s',{'email': 'dummy@test.com'},
+                {
+                    "Authorization": "Bearer your-token"
+                }, {
+                onSuccess : function(context, data) {
+                    Log.info('httpPost call success');
+                    context.selectedAcr = data.status;
+                    executeStep(1);
+                }, onFail : function(context, data) {
+                    Log.info('httpPost call failed');
+                    context.selectedAcr = 'FAILED';
+                    executeStep(1);
+                }
+            });
+}
+
+]]></AuthenticationScript>
+        <AuthenticationType>flow</AuthenticationType>
+    </LocalAndOutBoundAuthenticationConfig>
+    <RequestPathAuthenticatorConfigs></RequestPathAuthenticatorConfigs>
+    <InboundProvisioningConfig></InboundProvisioningConfig>
+    <OutboundProvisioningConfig></OutboundProvisioningConfig>
+    <ClaimConfig>
+        <AlwaysSendMappedLocalSubjectId>true</AlwaysSendMappedLocalSubjectId>
+    </ClaimConfig>
+    <PermissionAndRoleConfig></PermissionAndRoleConfig>
+</ServiceProvider>


### PR DESCRIPTION
## Purpose

This pull request aims to resolve issue [[#15679](https://github.com/wso2/product-is/issues/15679)](https://github.com/wso2/product-is/issues/15679) - Enable sending headers with HTTP requests.

The problem identified was that the `httpPost` and `httpGet` methods in the Adaptive Authentication script lacked the ability to send HTTP headers along with the request. Furthermore, the `httpPost` method only supported JSON payloads.

## Goals

The goal of this pull request is to enhance the `httpPost` and `httpGet` methods to:

1. Allow sending HTTP headers with the request.
2. Support multiple content types for the `httpPost` payload, including `application/json`, and `application/x-www-form-urlencoded.`

## Approach

The proposed solution introduce new methods `httpGetWithHeaders` and `httpPostWithHeaders` methods that can send requests with headers

To achieve the aforementioned goals, the proposed solution introduces new methods:

- **`httpGetWithHeaders`**: This method performs an HTTP GET request with headers.
- **`httpPostWithHeaders`**: This method executes an HTTP POST request with headers, payload data, and event handlers.

Additionally, the `httpPost` function has been extended to handle different payload types based on the `Content-Type` header.

## **Documentation**

### **`httpGetWithHeaders` Method**

The **`httpGetWithHeaders`** method sends an HTTP GET request to the provided endpoint URL with headers

Parameters for `httpGetWithHeaders`:

1. **`epUrl`** : This is the endpoint URL where the HTTP GET request will be sent.
2. **`headers`** : This is a map containing the request headers.
3. **`eventHandlers`** : This is a map containing the event handlers. You can specify actions for **`onSuccess`** and **`onFail`** events.

### **`httpPostWithHeaders` Method**

The **`httpPostWithHeaders`** method sends an HTTP POST request to the provided endpoint URL. This method can handle payload data, headers, and event handlers.

Parameters for **`httpPostWithHeaders`**:

1. **`epUrl`** : This is the endpoint URL where the HTTP POST request will be sent.
2. **`payloadData`** : This is a map containing the data you want to send with the HTTP POST request.
3. **`headers`** : This is a map containing the request headers.
4. **`eventHandlers`** : This is a map containing the event handlers. You can specify actions for **`onSuccess`** and **`onFail`** events.

## **Examples**

### **`httpGetWithHeaders` Example**

Here's an example of how you can use the **`httpGetWithHeaders`** method to send an HTTP GET request with headers and event handlers:

```jsx

var onLoginRequest = function(context) {
    // Define the endpoint URL
    var getEndpointUrl = 'https://webhook.site/4c09b592-a272-4a55-865f-7edf5a69326f';

    // Define the headers
    var headers = {
        "Accept": "application/json",
        "Authorization": "Bearer your-token"
    };

    // Define eventHandlers if needed
    var eventHandlers = {
        onSuccess: function (context, data) {
            Log.info('HTTP GET request successful');
        },
        onFail: function (context, data) {
            Log.error('HTTP GET request failed');
        }
    };

    httpGetWithHeaders(getEndpointUrl, headers, eventHandlers);

    // Execute the next step in the authentication script
    executeStep(1);
};

```

### **`httpPostWithHeaders` Example**

Here's an example of how you can use the **`httpPostWithHeaders`** method to send an HTTP POST request with payload data, headers, and event handlers:

```jsx

var onLoginRequest = function(context) {
    // Define the endpoint URL
    var postEndpointUrl = 'https://webhook.site/4c09b592-a272-4a55-865f-7edf5a69326f';

    // Define the payload data
    var payloadData = {
        "username": "Marcel",
        "password": "supersecret"
    };

    // Define the headers
    var headers = {
        "Content-Type": "application/json"
    };

    // Define eventHandlers if needed
    var eventHandlers = {
        onSuccess: function (context, data) {
            Log.info('HTTP POST request successful');
        },
        onFail: function (context, data) {
            Log.error('HTTP POST request failed');
        }
    };

    httpPostWithHeaders(postEndpointUrl, payloadData, headers, eventHandlers);

    // Execute the next step in the authentication script
    executeStep(1);
};

```