### PR TITLE
Use createJsGraphBuilderFactoryFromConfig function from FrameworkUtils

### DIFF
--- a/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/pom.xml
@@ -112,7 +112,6 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
-            <version>${identity.organization.management.core.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/pom.xml
@@ -109,6 +109,12 @@
             <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
             <artifactId>httpasyncclient</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+            <version>${identity.organization.management.core.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/analytics/CallAnalyticsFunctionImplTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/analytics/CallAnalyticsFunctionImplTest.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.conditional.auth.functions.analytics;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.dao.impl.CacheBackedLongWaitStatusDAO;
@@ -75,6 +76,7 @@ public class CallAnalyticsFunctionImplTest extends JsSequenceHandlerAbstractTest
 
         super.setUp();
 
+        CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME = true;
         sequenceHandlerRunner.registerJsFunction("callAnalytics", new CallAnalyticsFunctionImpl());
         UserRealm userRealm = realmService.getTenantUserRealm(-1234);
         userRealm.getUserStoreManager().addRole("admin", new String[]{"admin", "test_user"}, null);

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.choreo/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.choreo/pom.xml
@@ -135,7 +135,6 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
-            <version>${identity.organization.management.core.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.choreo/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.choreo/pom.xml
@@ -132,6 +132,12 @@
             <artifactId>jsr311-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+            <version>${identity.organization.management.core.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.choreo/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/choreo/CallChoreoFunctionImplTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.choreo/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/choreo/CallChoreoFunctionImplTest.java
@@ -35,6 +35,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.dao.impl.CacheBackedLongWaitStatusDAO;
@@ -110,6 +111,7 @@ public class CallChoreoFunctionImplTest extends JsSequenceHandlerAbstractTest {
 
         super.setUp();
 
+        CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME = true;
         sequenceHandlerRunner.registerJsFunction("callChoreo", new CallChoreoFunctionImpl());
         UserRealm userRealm = realmService.getTenantUserRealm(-1234);
         userRealm.getUserStoreManager().addRole("admin", new String[]{"admin", "test_user"}, null);

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.elk/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.elk/pom.xml
@@ -96,7 +96,6 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
-            <version>${identity.organization.management.core.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.elk/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.elk/pom.xml
@@ -93,6 +93,12 @@
             <artifactId>org.wso2.carbon.identity.conditional.auth.functions.test.utils</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+            <version>${identity.organization.management.core.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.elk/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/elk/CallElasticFunctionImplTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.elk/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/elk/CallElasticFunctionImplTest.java
@@ -23,6 +23,7 @@ import org.json.JSONObject;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.dao.impl.CacheBackedLongWaitStatusDAO;
@@ -76,6 +77,7 @@ public class CallElasticFunctionImplTest extends JsSequenceHandlerAbstractTest {
     protected void initClass() throws Exception {
 
         super.setUp();
+        CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME = true;
         sequenceHandlerRunner.registerJsFunction("callElastic", new CallElasticFunctionImpl());
     }
 

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/pom.xml
@@ -108,6 +108,12 @@
             <artifactId>org.wso2.carbon.crypto.impl</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+            <version>${identity.organization.management.core.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/pom.xml
@@ -111,7 +111,6 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
-            <version>${identity.organization.management.core.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/CookieFunctionImplTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/CookieFunctionImplTest.java
@@ -27,6 +27,7 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.core.internal.CarbonCoreDataHolder;
 import org.wso2.carbon.crypto.impl.DefaultCryptoService;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
@@ -68,6 +69,7 @@ public class CookieFunctionImplTest extends JsSequenceHandlerAbstractTest {
     protected void setUp() throws Exception {
 
         super.setUp();
+        CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME = true;
         sequenceHandlerRunner.registerJsFunction("setCookie", (SetCookieFunction) new CookieFunctionImpl()::setCookie);
         sequenceHandlerRunner.registerJsFunction("getCookieValue", (GetCookieFunction) new CookieFunctionImpl()
                 ::getCookieValue);

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPGetFunctionImplTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPGetFunctionImplTest.java
@@ -21,6 +21,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.dao.impl.CacheBackedLongWaitStatusDAO;
@@ -80,6 +81,7 @@ public class HTTPGetFunctionImplTest extends JsSequenceHandlerAbstractTest {
     protected void initClass() throws Exception {
 
         super.setUp();
+        CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME = true;
         LongWaitStatusDAOImpl daoImpl = new LongWaitStatusDAOImpl();
         CacheBackedLongWaitStatusDAO cacheBackedDao = new CacheBackedLongWaitStatusDAO(daoImpl);
         int connectionTimeout = 5000;

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPPostFunctionImplTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/http/HTTPPostFunctionImplTest.java
@@ -21,6 +21,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.dao.impl.CacheBackedLongWaitStatusDAO;
@@ -82,6 +83,7 @@ public class HTTPPostFunctionImplTest extends JsSequenceHandlerAbstractTest {
     protected void initClass() throws Exception {
 
         super.setUp();
+        CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME = true;
         LongWaitStatusDAOImpl daoImpl = new LongWaitStatusDAOImpl();
         CacheBackedLongWaitStatusDAO cacheBackedDao = new CacheBackedLongWaitStatusDAO(daoImpl);
         int connectionTimeout = 5000;

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.notification/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/notification/SendEmailFunctionImplTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.notification/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/notification/SendEmailFunctionImplTest.java
@@ -23,6 +23,7 @@ import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
@@ -58,6 +59,7 @@ public class SendEmailFunctionImplTest extends JsSequenceHandlerAbstractTest {
 
         super.setUp();
 
+        CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME = true;
         sequenceHandlerRunner.registerJsFunction("sendEmail", new SendEmailFunctionImpl());
     }
 

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.session/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.session/pom.xml
@@ -68,6 +68,12 @@
             <classifier>runtime</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+            <version>${identity.organization.management.core.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.session/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.session/pom.xml
@@ -71,7 +71,6 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
-            <version>${identity.organization.management.core.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/pom.xml
@@ -115,7 +115,6 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
-            <version>${identity.organization.management.core.version}</version>
         </dependency>
     </dependencies>
 

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/pom.xml
@@ -104,6 +104,19 @@
             <artifactId>nashorn-core</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+            <version>${identity.organization.management.core.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/MicrosoftEmailVerificationFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/MicrosoftEmailVerificationFunctionImpl.java
@@ -78,7 +78,7 @@ public class MicrosoftEmailVerificationFunctionImpl implements MicrosoftEmailVer
         byte[] decoded = Base64.decodeBase64(base64Body.getBytes());
         Set<Map.Entry<String, Object>> jwtAttributeSet = new HashSet<>();
         try {
-            jwtAttributeSet = JSONObjectUtils.parseJSONObject(new String(decoded)).entrySet();
+            jwtAttributeSet = JSONObjectUtils.parse(new String(decoded)).entrySet();
         } catch (ParseException e) {
             LOG.error("Error occurred while parsing JWT provided by federated IDP: ", e);
         }

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/model/JsWrapperFactoryProvider.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/model/JsWrapperFactoryProvider.java
@@ -19,7 +19,7 @@
 package org.wso2.carbon.identity.conditional.auth.functions.user.model;
 
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.openjdk.nashorn.JsOpenJdkNashornGraphBuilderFactory;
-import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 
 /**
  * Singleton to get the appropriate Javascript Proxy Object Wrapper Factory.
@@ -32,8 +32,7 @@ public class JsWrapperFactoryProvider {
 
     private JsWrapperFactoryProvider() {
 
-        if (FrameworkServiceDataHolder.getInstance().
-                getJsGraphBuilderFactory() instanceof JsOpenJdkNashornGraphBuilderFactory) {
+        if (FrameworkUtils.createJsGraphBuilderFactoryFromConfig() instanceof JsOpenJdkNashornGraphBuilderFactory) {
             jsWrapperBaseFactory = new JsOpenJdkNashornWrapperFactory();
         } else {
             jsWrapperBaseFactory = new JsWrapperFactory();

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/user/HasAnyOfTheRolesFunctionImplTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/user/HasAnyOfTheRolesFunctionImplTest.java
@@ -22,6 +22,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
@@ -56,6 +57,7 @@ public class HasAnyOfTheRolesFunctionImplTest extends JsSequenceHandlerAbstractT
 
         super.setUp();
 
+        CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME = true;
         sequenceHandlerRunner.registerJsFunction("hasAnyOfTheRoles", new HasAnyOfTheRolesFunctionImpl());
         UserRealm userRealm = realmService.getTenantUserRealm(-1234);
         userRealm.getUserStoreManager().addRole("admin", new String[]{"test_user1", "test_user2"}, null);

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/user/HasRoleFunctionImplTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/user/HasRoleFunctionImplTest.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.conditional.auth.functions.user;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
@@ -58,6 +59,7 @@ public class HasRoleFunctionImplTest extends JsSequenceHandlerAbstractTest {
 
         super.setUp();
 
+        CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME = true;
         sequenceHandlerRunner.registerJsFunction("hasRole", new HasRoleFunctionImpl());
         UserRealm userRealm = realmService.getTenantUserRealm(-1234);
         userRealm.getUserStoreManager().addRole("admin", new String[]{"test_user1", "test_user2"}, null);

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/user/IsMemberOfAnyOfGroupsFunctionImplTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/user/IsMemberOfAnyOfGroupsFunctionImplTest.java
@@ -22,6 +22,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
@@ -55,6 +56,7 @@ public class IsMemberOfAnyOfGroupsFunctionImplTest extends JsSequenceHandlerAbst
     protected void setUp() throws Exception {
 
         super.setUp();
+        CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME = true;
         sequenceHandlerRunner.registerJsFunction("isMemberOfAnyOfGroups",
                 new IsMemberOfAnyOfGroupsFunctionImpl());
         UserRealm userRealm = realmService.getTenantUserRealm(-1234);

--- a/pom.xml
+++ b/pom.xml
@@ -474,10 +474,11 @@
         </plugins>
     </build>
     <properties>
-        <carbon.kernel.version>4.6.3-m5</carbon.kernel.version>
+        <carbon.kernel.version>4.9.17</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.6.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.user.package.import.version.range>[1.0.1, 2.0.0)</carbon.user.package.import.version.range>
-        <carbon.identity.framework.version>5.22.0</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.509</carbon.identity.framework.version>
+        <identity.organization.management.core.version>1.0.89</identity.organization.management.core.version>
         <carbon.identity.framework.testutils.version>5.20.447</carbon.identity.framework.testutils.version>
         <carbon.identity.package.import.version.range>[5.14.0, 7.0.0)</carbon.identity.package.import.version.range>
         <identity.governance.version>1.1.17</identity.governance.version>

--- a/pom.xml
+++ b/pom.xml
@@ -294,6 +294,12 @@
                 <artifactId>org.wso2.carbon.crypto.impl</artifactId>
                 <version>${carbon.crypto.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+                <version>${identity.organization.management.core.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Purpose
> Use createJsGraphBuilderFactoryFromConfig function from FrameworkUtils as using the function from internal package causes class not found exception since internal package is not exported. 

## Related Issue
> https://github.com/wso2/product-is/issues/17132