### PR TITLE
Fix PR builder and http component test failure

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -1,7 +1,7 @@
 # This workflow will build the project on pull requests with tests
 # Uses:
 #   OS: ubuntu-latest
-#   JDK: Adopt JDK 8
+#   JDK: Adopt JDK 11
 
 name: PR Builder
 
@@ -17,15 +17,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-  env:
-    JAVA_TOOL_OPTIONS: "-Djdk.util.zip.disableZip64ExtraFieldValidation=true -Djdk.nio.zipfs.allowDotZipEntry=true"
+    env:
+      JAVA_TOOL_OPTIONS: "-Djdk.util.zip.disableZip64ExtraFieldValidation=true -Djdk.nio.zipfs.allowDotZipEntry=true"
 
     steps:
       - uses: actions/checkout@v2
       - name: Set up Adopt JDK 11
         uses: actions/setup-java@v2
         with:
-          java-version: [ 11.0.19+7 ]
+          java-version: "11"
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/pom.xml
@@ -197,6 +197,23 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <argLine>
+                        --add-opens=java.base/java.lang=ALL-UNNAMED
+                        --add-opens=java.base/java.util=ALL-UNNAMED
+                        --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
+                        --add-opens=java.base/java.io=ALL-UNNAMED
+                        --add-opens=java.base/sun.nio.fs=ALL-UNNAMED
+                    </argLine>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/src/test/resources/testng.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="org.wso2.carbon.identity.conditional.auth.functions.http.test">
+    <test name="org.wso2.carbon.identity.conditional.auth.functions.http.test" parallel="false">
+        <classes>
+            <class name="org.wso2.carbon.identity.conditional.auth.functions.http.CookieFunctionImplTest"/>
+            <class name="org.wso2.carbon.identity.conditional.auth.functions.http.HTTPGetFunctionImplTest"/>
+            <class name="org.wso2.carbon.identity.conditional.auth.functions.http.HTTPPostFunctionImplTest"/>
+            <class name="org.wso2.carbon.identity.conditional.auth.functions.http.SimpleCryptoProviderTest"/>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
## Purpose

- PR builder was failing continuously due to an indentation issue in the workflow yaml file. This PR fixes that issue and set repo to be built on the latest java 11 patch version.
- Intermittent/ frequent build issue was observed in `org.wso2.carbon.identity.conditional.auth.functions.http` component due to a test/ s failures in the http get or post related functions. As per the logs, this is due to `httpGet`/ `httpPost` functions getting undefined while executing the JS graph. 
    - The root cause is as follows. Both of these tests extends the `JsSequenceHandlerAbstractTest` class which initializes the `JsSequenceHandlerRunner`. This class initializes the `jsFunctionRegistry`, `graphBuilderFactory`, etc within it's [init method](https://github.com/wso2-extensions/identity-conditional-auth-functions/blob/1ac08f106c7b6e08d4f9d9b5f2b503ccec4214de/components/org.wso2.carbon.identity.conditional.auth.functions.test.utils/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/test/utils/sequence/JsSequenceHandlerRunner.java#L105) and set them in the `FrameworkServiceDataHolder`. If the tests (i.e. `HTTPGetFunctionImplTest`, `HTTPPostFunctionImplTest`) happens to execute parallel, it could set different `jsFunctionRegistry`, `graphBuilderFactory`, etc objects in the `FrameworkServiceDataHolder`, while other test could be looking for it's js objects. This could lead to getting `httpGet`/ `httpPost` functions undefined error while obtaining the sequence config.
    - This PR fixes above issue by making these tests execute sequentially.