### PR TITLE
Fix authentication Context being null in authenticated user JS proxy object

### DIFF
--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user.store/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/store/UserStoreFunctions.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user.store/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/store/UserStoreFunctions.java
@@ -124,7 +124,7 @@ public class UserStoreFunctions implements GetUserWithClaimValues {
                     }
                     authenticatedUser.setUserName(username);
                     authenticatedUser.setTenantDomain(tenantDomain);
-                    if (authenticationContext != null) {
+                    if (authenticationContext == null) {
                         return (JsAuthenticatedUser) JsWrapperFactoryProvider.getInstance().getWrapperFactory().
                                 createJsAuthenticatedUser(authenticatedUser);
                     }


### PR DESCRIPTION
## Purpose
- Fix authentication Context being null in authenticated user JS proxy object