### PR TITLE
Add dynamic import for OpenJDK Nashorn scriptObjectMirror

### DIFF
--- a/components/org.wso2.carbon.identity.conditional.auth.functions.common/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.common/pom.xml
@@ -39,6 +39,7 @@
         <dependency>
             <groupId>org.openjdk.nashorn</groupId>
             <artifactId>nashorn-core</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.logging</groupId>
@@ -105,6 +106,11 @@
                             !org.wso2.carbon.identity.conditional.auth.functions.common.internal,
                             org.wso2.carbon.identity.conditional.auth.functions.common.*
                         </Export-Package>
+                        <DynamicImport-Package>
+                            org.apache.http.auth,
+                            jdk.nashorn.api.scripting,
+                            org.openjdk.nashorn.api.scripting
+                        </DynamicImport-Package>
                         <Import-Package>
                             org.osgi.framework,
                             org.apache.commons.lang,


### PR DESCRIPTION
## Purpose
To resolve the issue of OpenJDK Nashorn scriptObjectMirror class not being found for Open JDK nashorn based script execution engine, we need to add these dynamic imports.

This was working in authentication framework due to the following import
https://github.com/wso2/carbon-identity-framework/blob/ae763b68543c37dce3b861addee3a8dd4aac7603/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/pom.xml#L315
