### PR TITLE
Import org.graalvm.polyglot package and sub-packages

### DIFF
--- a/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/pom.xml
@@ -187,6 +187,9 @@
                             org.wso2.carbon.utils.*; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.context,
                         </Import-Package>
+                        <DynamicImport-Package>
+                            org.graalvm.polyglot.*
+                        </DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.analytics/pom.xml
@@ -188,7 +188,7 @@
                             org.wso2.carbon.context,
                         </Import-Package>
                         <DynamicImport-Package>
-                            org.graalvm.polyglot.*
+                            org.graalvm.polyglot
                         </DynamicImport-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.choreo/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.choreo/pom.xml
@@ -221,7 +221,7 @@
                             org.wso2.carbon.identity.core.cache; version="${carbon.identity.package.import.version.range}",
                         </Import-Package>
                         <DynamicImport-Package>
-                            org.graalvm.polyglot.*
+                            org.graalvm.polyglot
                         </DynamicImport-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.choreo/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.choreo/pom.xml
@@ -220,6 +220,9 @@
                             com.nimbusds.jwt.*;version="${nimbusds.osgi.version.range}",
                             org.wso2.carbon.identity.core.cache; version="${carbon.identity.package.import.version.range}",
                         </Import-Package>
+                        <DynamicImport-Package>
+                            org.graalvm.polyglot.*
+                        </DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.common/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.common/pom.xml
@@ -107,6 +107,7 @@
                             org.wso2.carbon.identity.conditional.auth.functions.common.*
                         </Export-Package>
                         <DynamicImport-Package>
+                            org.graalvm.polyglot.*,
                             org.apache.http.auth,
                             jdk.nashorn.api.scripting,
                             org.openjdk.nashorn.api.scripting

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.common/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.common/pom.xml
@@ -107,7 +107,7 @@
                             org.wso2.carbon.identity.conditional.auth.functions.common.*
                         </Export-Package>
                         <DynamicImport-Package>
-                            org.graalvm.polyglot.*,
+                            org.graalvm.polyglot,
                             org.apache.http.auth,
                             jdk.nashorn.api.scripting,
                             org.openjdk.nashorn.api.scripting

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.elk/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.elk/pom.xml
@@ -157,7 +157,7 @@
                             org.wso2.carbon.utils.*;version="${carbon.kernel.package.import.version.range}",
                         </Import-Package>
                         <DynamicImport-Package>
-                            org.graalvm.polyglot.*
+                            org.graalvm.polyglot
                         </DynamicImport-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.elk/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.elk/pom.xml
@@ -147,6 +147,7 @@
                             org.wso2.carbon.identity.application.authentication.framework.config.model.graph; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.context; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.exception; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.util; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.conditional.auth.functions.common.auth; version="${org.wso2.carbon.identity.conditional.auth.functions.version.range}",
                             org.wso2.carbon.identity.conditional.auth.functions.common.utils; version="${org.wso2.carbon.identity.conditional.auth.functions.version.range}",
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.package.import.version.range}",
@@ -155,6 +156,9 @@
                             org.wso2.carbon.identity.governance.common; version="${identity.governance.import.version.range}",
                             org.wso2.carbon.utils.*;version="${carbon.kernel.package.import.version.range}",
                         </Import-Package>
+                        <DynamicImport-Package>
+                            org.graalvm.polyglot.*
+                        </DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/pom.xml
@@ -208,7 +208,7 @@
                             org.wso2.carbon.context,
                         </Import-Package>
                         <DynamicImport-Package>
-                            org.graalvm.polyglot.*
+                            org.graalvm.polyglot
                         </DynamicImport-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/pom.xml
@@ -153,6 +153,8 @@
                             org.apache.commons.collections,
                             org.apache.commons.io,
                             org.apache.commons.lang,
+                            org.apache.commons.lang3,
+                            org.apache.commons.lang3.tuple,
                             org.apache.commons.logging,
                             org.apache.http.entity,
                             org.apache.http.impl,
@@ -164,6 +166,8 @@
                             org.apache.http.impl.client,
                             org.apache.http.conn,
                             org.apache.http.message,
+                            com.google.gson,
+                            com.google.gson.reflect,
                             org.json.simple,
                             org.json.simple.parser,
                             org.apache.http,
@@ -187,6 +191,8 @@
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.config.model.graph;
                             version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.util;
+                            version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.security.keystore.service.*;
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.package.import.version.range}",
@@ -201,6 +207,9 @@
                             org.wso2.carbon.identity.core.cache; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.context,
                         </Import-Package>
+                        <DynamicImport-Package>
+                            org.graalvm.polyglot.*
+                        </DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.jwt.decode/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.jwt.decode/pom.xml
@@ -101,6 +101,9 @@
                             com.nimbusds.jose.*;version="${nimbusds.osgi.version.range}",
                             net.minidev.json; version="${net.minidev.json.imp.pkg.version.range}"
                         </Import-Package>
+                        <DynamicImport-Package>
+                            org.graalvm.polyglot.*
+                        </DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.jwt.decode/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.jwt.decode/pom.xml
@@ -102,7 +102,7 @@
                             net.minidev.json; version="${net.minidev.json.imp.pkg.version.range}"
                         </Import-Package>
                         <DynamicImport-Package>
-                            org.graalvm.polyglot.*
+                            org.graalvm.polyglot
                         </DynamicImport-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.notification/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.notification/pom.xml
@@ -135,12 +135,17 @@
                             org.wso2.carbon.identity.event; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.event; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.services; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.event.handler.notification;
+                            version="${identity.event.handler.notification.version.range}",
                             org.wso2.carbon.identity.event.handler.notification.exception;
                             version="${identity.event.handler.notification.version.range}",
                             org.wso2.carbon.identity.central.log.mgt.utils; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.utils*;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.service; version="${carbon.kernel.package.import.version.range}"
                         </Import-Package>
+                        <DynamicImport-Package>
+                            org.graalvm.polyglot.*
+                        </DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.notification/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.notification/pom.xml
@@ -144,7 +144,7 @@
                             org.wso2.carbon.user.core.service; version="${carbon.kernel.package.import.version.range}"
                         </Import-Package>
                         <DynamicImport-Package>
-                            org.graalvm.polyglot.*
+                            org.graalvm.polyglot
                         </DynamicImport-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user.store/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user.store/pom.xml
@@ -126,7 +126,7 @@
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.package.import.version.range}"
                         </Import-Package>
                         <DynamicImport-Package>
-                            org.graalvm.polyglot.*
+                            org.graalvm.polyglot
                         </DynamicImport-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user.store/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user.store/pom.xml
@@ -113,6 +113,7 @@
                             org.wso2.carbon.identity.application.authentication.framework.util; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.exception; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.model; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.base; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.config.model.graph; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.config.model; version="${carbon.identity.package.import.version.range}",
@@ -124,6 +125,9 @@
                             org.wso2.carbon.user.api; version="${carbon.user.package.import.version.range}",
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.package.import.version.range}"
                         </Import-Package>
+                        <DynamicImport-Package>
+                            org.graalvm.polyglot.*
+                        </DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/pom.xml
@@ -240,7 +240,8 @@
                             org.wso2.carbon.utils*;version="${carbon.kernel.package.import.version.range}"
                         </Import-Package>
                         <DynamicImport-Package>
-                            org.graalvm.polyglot.*
+                            org.graalvm.polyglot,
+                            org.graalvm.polyglot.proxy
                         </DynamicImport-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/pom.xml
@@ -169,6 +169,7 @@
                             org.wso2.carbon.identity.conditional.auth.functions.user.*
                         </Export-Package>
                         <Import-Package>
+                            org.apache.commons.codec.binary,
                             org.apache.commons.lang,
                             org.apache.commons.logging,
                             org.osgi.service.component,
@@ -200,6 +201,8 @@
                             org.wso2.carbon.identity.application.authentication.framework.config.model.graph;
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.config.model.graph.graaljs;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.base;
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.config.model;
                             version="${carbon.identity.package.import.version.range}",
@@ -236,6 +239,9 @@
                             org.wso2.carbon.identity.conditional.auth.functions.common.utils,
                             org.wso2.carbon.utils*;version="${carbon.kernel.package.import.version.range}"
                         </Import-Package>
+                        <DynamicImport-Package>
+                            org.graalvm.polyglot.*
+                        </DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.utils/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.utils/pom.xml
@@ -129,6 +129,9 @@
                             org.wso2.carbon.utils*;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.package.import.version.range}"
                         </Import-Package>
+                        <DynamicImport-Package>
+                            org.graalvm.polyglot.*
+                        </DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.utils/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.utils/pom.xml
@@ -130,7 +130,7 @@
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.package.import.version.range}"
                         </Import-Package>
                         <DynamicImport-Package>
-                            org.graalvm.polyglot.*
+                            org.graalvm.polyglot
                         </DynamicImport-Package>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
## Purpose
- We need to bundle graal-sdk as an OSGi bundle and expose only the selected packages.
- So required packages need to be imported.
- This PR adds the required imports

### Related Issue
- https://github.com/wso2/product-is/issues/21276