### PR TITLE
Fix memory leak of the callChoreo access token request helper function

### DIFF
--- a/components/org.wso2.carbon.identity.conditional.auth.functions.choreo/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/choreo/CallChoreoFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.choreo/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/choreo/CallChoreoFunctionImpl.java
@@ -343,7 +343,8 @@ public class CallChoreoFunctionImpl implements CallChoreoFunction {
 
             boolean isFailure = false;
             try {
-                LOG.debug("Access token response received.");
+                LOG.info("Access token response received. Session data key: " +
+                        authenticationContext.getContextIdentifier());
                 int responseCode = httpResponse.getStatusLine().getStatusCode();
                 if (responseCode == HTTP_STATUS_OK) {
                     Type responseBodyType = new TypeToken<Map<String, String>>() { }.getType();
@@ -372,6 +373,8 @@ public class CallChoreoFunctionImpl implements CallChoreoFunction {
                 LOG.error("Error occurred while handling the token response from Choreo. Session data key: " +
                         authenticationContext.getContextIdentifier(), e);
                 isFailure = true;
+            } finally {
+                EntityUtils.consumeQuietly(httpResponse.getEntity());
             }
 
             if (isFailure) {


### PR DESCRIPTION
## Purpose
> There is possible memory leak due to not closing the http connection after the required response is received.

In httpClient version 5.x the automatic resource deallocation happens but in httpClient version 4.x the deallocation has to be done.
ex: EntityUtils.consume(entityOne);
Ref:- https://www.baeldung.com/apache-httpclient-vs-closeablehttpclient#1-automatic-resource-deallocation-httpclient-4x

```
httpClient.execute(httpGetOne, responseOne -> {
          HttpEntity entityOne = responseOne.getEntity();
          EntityUtils.consume(entityOne);
          assertThat(responseOne.getCode()).isEqualTo(HttpStatus.SC_OK);
          return responseOne;
      });
```