### PR TITLE
Deprecate session related functions

### DIFF
--- a/components/org.wso2.carbon.identity.conditional.auth.functions.session/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/session/function/ExecuteActionFunction.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.session/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/session/function/ExecuteActionFunction.java
@@ -24,8 +24,11 @@ import java.util.Map;
 
 /**
  * Function definition for verify some defined requirement is fulfilled.
+ *
+ * @deprecated
  */
 @FunctionalInterface
+@Deprecated
 public interface ExecuteActionFunction {
 
     /**

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.session/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/session/function/GetSessionDataFunction.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.session/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/session/function/GetSessionDataFunction.java
@@ -35,7 +35,10 @@ import java.util.Map;
 /**
  * Represents javascript function provided in conditional authentication to retrieve active session data for given user.
  * The purpose is to perform dynamic authentication selection based on the active session count.
+ *
+ * @deprecated
  */
+@Deprecated
 public class GetSessionDataFunction implements GetUserSessionDataFunction {
 
     private static final Log log = LogFactory.getLog(GetSessionDataFunction.class);

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.session/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/session/function/GetUserSessionDataFunction.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.session/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/session/function/GetUserSessionDataFunction.java
@@ -26,8 +26,11 @@ import java.util.Map;
 
 /**
  * Function definition for retrieving data.
+ *
+ * @deprecated
  */
 @FunctionalInterface
+@Deprecated
 public interface GetUserSessionDataFunction {
 
     /**

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.session/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/session/function/IsWithinSessionLimitFunction.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.session/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/session/function/IsWithinSessionLimitFunction.java
@@ -25,8 +25,11 @@ import java.util.Map;
 
 /**
  * Function definition for verify some defined requirement is fulfilled.
+ *
+ * @deprecated
  */
 @FunctionalInterface
+@Deprecated
 public interface IsWithinSessionLimitFunction {
 
     /**

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.session/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/session/function/IsWithinSessionLimitFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.session/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/session/function/IsWithinSessionLimitFunctionImpl.java
@@ -47,7 +47,10 @@ import static java.lang.Integer.parseInt;
  * Represents javascript function provided in conditional authentication to check if the given user has valid number of
  * sessions.
  * The purpose is to perform dynamic authentication selection based on the active session count.
+ *
+ * @deprecated
  */
+@Deprecated
 public class IsWithinSessionLimitFunctionImpl implements IsWithinSessionLimitFunction {
 
     private static final Log log = LogFactory.getLog(IsWithinSessionLimitFunctionImpl.class);

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.session/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/session/function/KillSessionFunction.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.session/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/session/function/KillSessionFunction.java
@@ -29,7 +29,10 @@ import java.util.Map;
 
 /**
  * Represents javascript function provided in conditional authentication to terminate a session with given sessionID.
+ *
+ * @deprecated
  */
+@Deprecated
 public class KillSessionFunction implements ExecuteActionFunction {
 
     private static final Log log = LogFactory.getLog(KillSessionFunction.class);


### PR DESCRIPTION
## Purpose
- `isWithinSessionLimit`, `killSession` and `getSessionData` functions are currently not packed with Identity Server
- There are maintained and packed functions in Identity Server which offer the same functionality
- So these functions will not be supported with the new GraalJS based adaptive authentication script engine implementation by default and will be deprecated.
- However the support can be provided similar to other functions