### PR TITLE
Provide capability to skip password pattern validation during on demand password migration

### DIFF
--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/UpdateUserPasswordFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/UpdateUserPasswordFunctionImpl.java
@@ -69,8 +69,9 @@ public class UpdateUserPasswordFunctionImpl implements UpdateUserPasswordFunctio
             throw new IllegalArgumentException("Password is not defined.");
         }
 
-        // Parse optional parameters list to extract necessary details to update user password.
+        // Parses the optional parameters list to extract necessary data for updating the user password.
         UserPasswordUpdateModel parsedParams = parseParameters(parameters);
+
         char[] newPassword = parsedParams.getNewPassword();
         Map<String, Object> eventHandlers = parsedParams.getEventHandlers();
         boolean skipPasswordValidation = parsedParams.isSkipPasswordValidation();

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/UpdateUserPasswordFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/UpdateUserPasswordFunctionImpl.java
@@ -120,45 +120,35 @@ public class UpdateUserPasswordFunctionImpl implements UpdateUserPasswordFunctio
      */
     private UserPasswordUpdateModel parseParameters(Object[] parameters) {
 
-        char[] newPassword;
-        Map<String, Object> eventHandlers = null;
-        boolean skipPasswordValidation = false;
+        char[] newPassword = ((String) parameters[0]).toCharArray();
+        UserPasswordUpdateModel.UserPasswordUpdateModelBuilder passwordUpdateModelBuilder = new
+                UserPasswordUpdateModel.UserPasswordUpdateModelBuilder(newPassword);
+
+        if (parameters.length == 1) {
+            LOG.debug("Only the password is provided.");
+            return passwordUpdateModelBuilder.build();
+        }
+
+        if (parameters[1] instanceof Map) {
+            passwordUpdateModelBuilder.eventHandlers((Map<String, Object>) parameters[1]);
+        } else {
+            throw new IllegalArgumentException("Invalid argument type. Expected eventHandlers " +
+                    "(Map<String, Object>).");
+        }
 
         if (parameters.length == 2) {
             LOG.debug("Both password and event handlers are provided.");
-            newPassword = ((String) parameters[0]).toCharArray();
-
-            if (parameters[1] instanceof Map) {
-                eventHandlers = (Map<String, Object>) parameters[1];
-            } else {
-                throw new IllegalArgumentException("Invalid argument type. Expected eventHandlers " +
-                        "(Map<String, Object>).");
-            }
-        } else if (parameters.length == 3) {
-            LOG.debug("Password, event handlers and skipPasswordValidation flag are provided.");
-            newPassword = ((String) parameters[0]).toCharArray();
-
-            if (parameters[1] instanceof Map) {
-                eventHandlers = (Map<String, Object>) parameters[1];
-            } else {
-                throw new IllegalArgumentException("Invalid argument type. Expected eventHandlers " +
-                        "(Map<String, Object>).");
-            }
-
-            if (parameters[2] instanceof Boolean) {
-                skipPasswordValidation = (Boolean) parameters[2];
-            } else {
-                throw new IllegalArgumentException("Invalid argument type. Expected skipPasswordValidation(Boolean).");
-            }
-        } else {
-            LOG.debug("Only the password is provided.");
-            newPassword = ((String) parameters[0]).toCharArray();
+            return passwordUpdateModelBuilder.build();
         }
 
-        return new UserPasswordUpdateModel.UserPasswordUpdateModelBuilder(newPassword).
-                eventHandlers(eventHandlers).
-                skipPasswordValidation(skipPasswordValidation).
-                build();
+        if (parameters[2] instanceof Boolean) {
+            passwordUpdateModelBuilder.skipPasswordValidation((Boolean) parameters[2]);
+        } else {
+            throw new IllegalArgumentException("Invalid argument type. Expected skipPasswordValidation(Boolean).");
+        }
+
+        LOG.debug("Password, event handlers and skipPasswordValidation flag are provided.");
+        return passwordUpdateModelBuilder.build();
     }
 
     private void doUpdatePassword(JsAuthenticatedUser user, char[] newPassword) throws FrameworkException {

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/UpdateUserPasswordFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/UpdateUserPasswordFunctionImpl.java
@@ -60,29 +60,35 @@ public class UpdateUserPasswordFunctionImpl implements UpdateUserPasswordFunctio
         Map<String, Object> eventHandlers = null;
         boolean skipPasswordValidation = false;
 
-        if (parameters.length >= 3) {
-            LOG.debug("Both password and event handlers are provided.");
-            newPassword = ((String) parameters[0]).toCharArray();
-
-            if (parameters[1] instanceof Map) {
-                eventHandlers = (Map<String, Object>) parameters[1];
-            } else {
-                throw new IllegalArgumentException("Invalid argument type. Expected eventHandlers " +
-                        "(Map<String, Object>).");
-            }
-
-            if (parameters[2] instanceof Boolean) {
-                skipPasswordValidation = (Boolean) parameters[2];
-            } else {
-                throw new IllegalArgumentException("Invalid argument type. Expected skipPasswordValidation flag.");
-            }
-        } else {
+        if (parameters.length == 1) {
             LOG.debug("Only the password is provided.");
             newPassword = ((String) parameters[0]).toCharArray();
+        } else {
+            LOG.debug("Password is provided.");
+            newPassword = ((String) parameters[0]).toCharArray();
+
+            for (int i = 1; i < parameters.length; i++) {
+                Object parameter = parameters[i];
+                if (parameter instanceof Map) {
+                    LOG.debug("Event handlers are provided.");
+                    eventHandlers = (Map<String, Object>) parameter;
+                } else if (parameter instanceof Boolean) {
+                    LOG.debug("SkipPasswordValidation flag are provided.");
+                    skipPasswordValidation = (Boolean) parameter;
+                } else {
+                    throw new IllegalArgumentException(
+                            "Invalid argument type. Expected eventHandlers (Map<String, Object>) or skipPasswordValidation(Boolean)."
+                    );
+                }
+            }
         }
 
         if (newPassword.length == 0) {
             throw new IllegalArgumentException("The provided password is empty.");
+        }
+
+        if (skipPasswordValidation) {
+            UserCoreUtil.setSkipPasswordPatternValidationThreadLocal(true);
         }
 
         if (eventHandlers != null) {

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/UpdateUserPasswordFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/UpdateUserPasswordFunctionImpl.java
@@ -45,6 +45,19 @@ public class UpdateUserPasswordFunctionImpl implements UpdateUserPasswordFunctio
 
     private static final Log LOG = LogFactory.getLog(UpdateUserPasswordFunctionImpl.class);
 
+    /**
+     * Updates the password of the user.
+     *
+     * The varargs passed as parameters will be processed in the following order.
+     * <ol>
+     *     <li> newPassword (String): New password to be updated. </li>
+     *     <li> eventHandlers (Map<String, Object>): Optional map of event handlers.</li>
+     *     <li> skipPasswordValidation (Boolean): Optional flag to skip password validation rules.</li>
+     * </ol>
+     * @param user       User subjected to the password update.
+     * @param parameters Optional details required for password update.
+     * @throws IllegalArgumentException If an error occurred while updating the password of the user.
+     */
     @Override
     @HostAccess.Export
     public void updateUserPassword(JsAuthenticatedUser user, Object... parameters) {
@@ -56,7 +69,7 @@ public class UpdateUserPasswordFunctionImpl implements UpdateUserPasswordFunctio
             throw new IllegalArgumentException("Password is not defined.");
         }
 
-        // Parse optional parameters list to extract required details to update user password.
+        // Parse optional parameters list to extract necessary details to update user password.
         UserPasswordUpdateModel parsedParams = parseParameters(parameters);
         char[] newPassword = parsedParams.getNewPassword();
         Map<String, Object> eventHandlers = parsedParams.getEventHandlers();

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/model/utils/UserPasswordUpdateModel.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/model/utils/UserPasswordUpdateModel.java
@@ -70,6 +70,7 @@ public class UserPasswordUpdateModel {
             this.eventHandlers = handlers;
             return this;
         }
+
         public UserPasswordUpdateModelBuilder skipPasswordValidation(boolean skip) {
 
             this.skipPasswordValidation = skip;

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/model/utils/UserPasswordUpdateModel.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/model/utils/UserPasswordUpdateModel.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.conditional.auth.functions.user.model.utils;
+
+import java.util.Map;
+
+/**
+ * This class represents required parameters to update user's password.
+ */
+public class UserPasswordUpdateModel {
+
+    private final char[] newPassword;
+    private final Map<String,Object> eventHandlers;
+    private final boolean skipPasswordValidation;
+
+    private UserPasswordUpdateModel(UserPasswordUpdateModelBuilder builder) {
+
+        this.newPassword           = builder.newPassword;
+        this.eventHandlers         = builder.eventHandlers;
+        this.skipPasswordValidation= builder.skipPasswordValidation;
+    }
+
+    public char[] getNewPassword() {
+
+        return newPassword.clone();
+    }
+
+    public Map<String,Object> getEventHandlers() {
+
+        return eventHandlers;
+    }
+
+    public boolean isSkipPasswordValidation() {
+
+        return skipPasswordValidation;
+    }
+
+    /**
+     * Builder class for {@link UserPasswordUpdateModel}
+     */
+    public static class UserPasswordUpdateModelBuilder {
+
+        private final char[] newPassword;
+        private Map<String,Object> eventHandlers;
+        private boolean skipPasswordValidation;
+
+        public UserPasswordUpdateModelBuilder(char[] newPassword) {
+
+            this.newPassword = newPassword;
+        }
+
+        public UserPasswordUpdateModelBuilder eventHandlers(Map<String,Object> handlers) {
+
+            this.eventHandlers = handlers;
+            return this;
+        }
+        public UserPasswordUpdateModelBuilder skipPasswordValidation(boolean skip) {
+
+            this.skipPasswordValidation = skip;
+            return this;
+        }
+
+        public UserPasswordUpdateModel build() {
+
+            return new UserPasswordUpdateModel(this);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/user/UpdateUserPasswordFunctionImplTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/user/UpdateUserPasswordFunctionImplTest.java
@@ -177,22 +177,29 @@ public class UpdateUserPasswordFunctionImplTest extends JsSequenceHandlerAbstrac
         JsAuthenticatedUser jsAuthenticatedUser = new JsOpenJdkNashornAuthenticatedUser(authenticatedUser);
 
         return new Object[][]{
-                {null, "newPassword", null, "User is not defined."},
-                {jsAuthenticatedUser, null, null, "Password is not defined."},
-                {jsAuthenticatedUser, "", null, "The provided password is empty."},
-                {jsAuthenticatedUser, "newPassword", Collections.EMPTY_LIST, "Invalid argument type. " +
-                        "Expected eventHandlers (Map<String, Object>)."}
+                // user, newPassword, eventHandlers, skipPasswordValidation, expectedError
+                {null, "newPassword", null, null, "User is not defined."},
+                {jsAuthenticatedUser, null, null, null, "Password is not defined."},
+                {jsAuthenticatedUser, "", null, null, "The provided password is empty."},
+                {jsAuthenticatedUser, "newPassword", Collections.EMPTY_LIST, true, "Invalid argument type. " +
+                        "Expected eventHandlers (Map<String, Object>) or skipPasswordValidation(Boolean)."},
+                {jsAuthenticatedUser, "newPassword", Collections.EMPTY_LIST, null,
+                        "Invalid argument type. Expected eventHandlers (Map<String, Object>) or " +
+                                "skipPasswordValidation(Boolean)."}
         };
     }
 
     @Test(dataProvider = "updateUserPasswordWithEmptyInputDataProvider")
     public void testUpdateUserPasswordWithEmptyInput(JsAuthenticatedUser user, String password,
-                                                     List<Object> eventHandlers, String errorMessage)
+                                                     List<Object> eventHandlers, Boolean skipPasswordValidation,
+                                                     String errorMessage)
             throws UserStoreException {
 
         try {
             if (password == null) {
                 testFunction.updateUserPassword(user);
+            } else if (eventHandlers != null && skipPasswordValidation != null) {
+                testFunction.updateUserPassword(user, password, eventHandlers, skipPasswordValidation);
             } else if (eventHandlers != null) {
                 testFunction.updateUserPassword(user, password, eventHandlers);
             } else {

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/user/UpdateUserPasswordFunctionImplTest.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/test/java/org/wso2/carbon/identity/conditional/auth/functions/user/UpdateUserPasswordFunctionImplTest.java
@@ -182,10 +182,7 @@ public class UpdateUserPasswordFunctionImplTest extends JsSequenceHandlerAbstrac
                 {jsAuthenticatedUser, null, null, null, "Password is not defined."},
                 {jsAuthenticatedUser, "", null, null, "The provided password is empty."},
                 {jsAuthenticatedUser, "newPassword", Collections.EMPTY_LIST, true, "Invalid argument type. " +
-                        "Expected eventHandlers (Map<String, Object>) or skipPasswordValidation(Boolean)."},
-                {jsAuthenticatedUser, "newPassword", Collections.EMPTY_LIST, null,
-                        "Invalid argument type. Expected eventHandlers (Map<String, Object>) or " +
-                                "skipPasswordValidation(Boolean)."}
+                        "Expected eventHandlers (Map<String, Object>)."}
         };
     }
 


### PR DESCRIPTION
This pull request enhances the `updateUserPassword` functionality by introducing a new parameter to bypass password validation and updates the corresponding test cases to support this change. It also improves error handling and logging for better maintainability and debugging.

### Enhancements to `updateUserPassword` functionality:
* Added a new `skipPasswordValidation` parameter to allow bypassing password pattern validation. This is implemented by setting a thread-local variable using `UserCoreUtil.setSkipPasswordPatternValidationThreadLocal`.
* Improved argument parsing to handle multiple optional parameters (`eventHandlers` and `skipPasswordValidation`) and updated error messages to reflect the expected argument types.

### Test case updates:
* Updated the `updateUserPasswordWithEmptyInputDataProvider` test data to include the new `skipPasswordValidation` parameter and modified the test logic to validate scenarios with this parameter.

### Related Issue
- https://github.com/wso2/product-is/issues/24228

---

### Usages

Current the password update during on demand password migration is supported through `updateUserPassword` adaptive function. With this improvement a new parameter is introduced to skip the validation process. 

As a result the users are expected to pass a fourth parameter in addition to User object, the password to be updated and eventHandlers. 

Ex: 
```
 updateUserPassword(user, "tom", {
     onSuccess: function(context) {
         // onSuccess even handler code goes here
     },
     onFail: function(context) {
         // onFail even handler code goes here
     }
 }, true);
```
Note the additional `true` at the end which specifies the password validation to be skipped.

This improvement would not affect the existing implementation of the `updateUserPassword` since the new parameter is passed as an Optional parameter and would fallback to default false if a value is not provided.