### PR TITLE
Add conditional auth functions to remove local user association and multiple user retrieval

### DIFF
--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user.store/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/store/GetUsersWithClaimValuesFunction.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user.store/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/store/GetUsersWithClaimValuesFunction.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.conditional.auth.functions.user.store;
+
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.JsAuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.JsAuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Function to retrieve a list of users with provided claim values.
+ */
+@FunctionalInterface
+public interface GetUsersWithClaimValuesFunction {
+
+    /**
+     * Get a list of users who have the claim values as provided in the adaptive script.
+     *
+     * @param claimMap                  Map of claims and its values.
+     * @param authenticationContext     Authentication context object
+     * @param parameters                Additional parameters provided from the adaptive script.
+     */
+    List<JsAuthenticatedUser> getUsersWithClaimValues(Map<String, String> claimMap,
+                                                      JsAuthenticationContext authenticationContext,
+                                                      String... parameters) throws FrameworkException;
+}

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user.store/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/store/GetUsersWithClaimValuesFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user.store/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/store/GetUsersWithClaimValuesFunctionImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.conditional.auth.functions.user.store;
+
+import java.util.List;
+import java.util.Map;
+import org.graalvm.polyglot.HostAccess;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.JsAuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.JsAuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
+
+/**
+ * Implementation of GetUsersWithClaimValuesFunction interface. This returns a list of users with provided claim values.
+ */
+public class GetUsersWithClaimValuesFunctionImpl implements GetUsersWithClaimValuesFunction {
+
+    @Override
+    @HostAccess.Export
+    public List<JsAuthenticatedUser> getUsersWithClaimValues(Map<String, String> claimMap,
+                                                             JsAuthenticationContext authenticationContext,
+                                                             String... parameters) throws FrameworkException {
+
+        return new UserStoreFunctions().getUsersWithClaimValues(claimMap, authenticationContext, parameters);
+    }
+}

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user.store/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/store/internal/UserStoreFunctionsServiceComponent.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user.store/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/store/internal/UserStoreFunctionsServiceComponent.java
@@ -29,6 +29,7 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.application.authentication.framework.JsFunctionRegistry;
 import org.wso2.carbon.identity.conditional.auth.functions.user.store.GetUserWithClaimValuesV2FunctionImpl;
+import org.wso2.carbon.identity.conditional.auth.functions.user.store.GetUsersWithClaimValuesFunctionImpl;
 import org.wso2.carbon.user.core.service.RealmService;
 
 /**
@@ -53,6 +54,8 @@ public class UserStoreFunctionsServiceComponent {
 
             jsFunctionRegistry.register(JsFunctionRegistry.Subsystem.SEQUENCE_HANDLER, "getUniqueUserWithClaimValues",
                     new GetUserWithClaimValuesV2FunctionImpl());
+            jsFunctionRegistry.register(JsFunctionRegistry.Subsystem.SEQUENCE_HANDLER, "getUsersWithClaimValues",
+                    new GetUsersWithClaimValuesFunctionImpl());
         } catch (Throwable e) {
             LOG.error("Error occurred during conditional authentication user functions bundle activation. ", e);
 

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/RemoveAssociatedLocalUserFunction.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/RemoveAssociatedLocalUserFunction.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.conditional.auth.functions.user;
+
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.JsAuthenticatedUser;
+
+/**
+ * Function to remove association with the local user for a federated user.
+ */
+@FunctionalInterface
+public interface RemoveAssociatedLocalUserFunction {
+
+    /**
+     * Remove association to the local user with federated user.
+     *
+     * @param federatedUser     Federated user.
+     */
+    boolean removeAssociatedLocalUser(JsAuthenticatedUser federatedUser);
+}

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/RemoveAssociatedLocalUserFunctionImpl.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/RemoveAssociatedLocalUserFunctionImpl.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.conditional.auth.functions.user;
+
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.graalvm.polyglot.HostAccess;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.JsAuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.user.profile.mgt.UserProfileAdmin;
+import org.wso2.carbon.identity.user.profile.mgt.UserProfileException;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+
+import java.util.Map;
+
+public class RemoveAssociatedLocalUserFunctionImpl implements RemoveAssociatedLocalUserFunction {
+
+    private static final Log LOG = LogFactory.getLog(RemoveAssociatedLocalUserFunctionImpl.class);
+
+    @Override
+    @HostAccess.Export
+    public boolean removeAssociatedLocalUser(JsAuthenticatedUser federatedUser) {
+
+        if (!federatedUser.getWrapped().isFederatedUser()) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("User " + federatedUser.getWrapped().getUserName() + " is not a federated user.");
+            }
+            return false;
+        }
+
+        String tenantDomain = federatedUser.getWrapped().getTenantDomain();
+        String externalIdpName = federatedUser.getWrapped().getFederatedIdPName();
+        String externalSubject = null;
+
+        try {
+            String userIdClaimURI = Utils.getUserIdClaimURI(externalIdpName, tenantDomain);
+            if (StringUtils.isNotEmpty(userIdClaimURI) &&
+                    MapUtils.isNotEmpty(federatedUser.getWrapped().getUserAttributes())) {
+                externalSubject = federatedUser.getWrapped().getUserAttributes().entrySet().stream().filter(
+                        userAttribute -> userAttribute.getKey().getRemoteClaim().getClaimUri()
+                                .equals(userIdClaimURI))
+                        .map(Map.Entry::getValue)
+                        .findFirst()
+                        .orElse(null);
+            } else {
+                if (StringUtils.isEmpty(userIdClaimURI) && LOG.isDebugEnabled()) {
+                    LOG.debug("No mapping found for userIdClaimURI in the IDP.");
+                }
+                externalSubject = federatedUser.getWrapped().getAuthenticatedSubjectIdentifier();
+            }
+        } catch (IdentityProviderManagementException e) {
+            String msg =
+                    "Error while retrieving identity provider by name: " + externalIdpName;
+            LOG.error(msg, e);
+        }
+
+        String associatedID = null;
+        UserProfileAdmin userProfileAdmin = UserProfileAdmin.getInstance();
+
+        try {
+            // Start tenant flow.
+            FrameworkUtils.startTenantFlow(tenantDomain);
+            associatedID = userProfileAdmin.getNameAssociatedWith(externalIdpName, externalSubject);
+        } catch (UserProfileException e) {
+            LOG.error("Error while getting associated local user ID for " + externalSubject, e);
+        } finally {
+            FrameworkUtils.endTenantFlow();
+        }
+
+        if (StringUtils.isBlank(associatedID)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("User " + federatedUser.getWrapped().getUserName() + " doesn't have an associated local" +
+                        " account.");
+            }
+            return false;
+        }
+
+        // Remove association with local user as an association exists.
+        try {
+            userProfileAdmin.removeAssociateIDForUser(associatedID, externalIdpName, externalSubject);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("User association removed successfully.");
+            }
+            return true;
+        } catch (UserProfileException e) {
+            String msg = "Error while removing association for user: " + federatedUser.getWrapped().getUserName()
+                    + " with federated IdP: " + externalIdpName;
+            LOG.error(msg, e);
+        }
+        return false;
+    }
+}

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/internal/UserFunctionsServiceComponent.java
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.user/src/main/java/org/wso2/carbon/identity/conditional/auth/functions/user/internal/UserFunctionsServiceComponent.java
@@ -51,6 +51,8 @@ import org.wso2.carbon.identity.conditional.auth.functions.user.HasRoleFunction;
 import org.wso2.carbon.identity.conditional.auth.functions.user.HasRoleFunctionImpl;
 import org.wso2.carbon.identity.conditional.auth.functions.user.IsAnyOfTheRolesAssignedToUserFunctionImpl;
 import org.wso2.carbon.identity.conditional.auth.functions.user.PromptIdentifierFunctionImpl;
+import org.wso2.carbon.identity.conditional.auth.functions.user.RemoveAssociatedLocalUserFunction;
+import org.wso2.carbon.identity.conditional.auth.functions.user.RemoveAssociatedLocalUserFunctionImpl;
 import org.wso2.carbon.identity.conditional.auth.functions.user.RemoveUserRolesFunction;
 import org.wso2.carbon.identity.conditional.auth.functions.user.RemoveUserRolesFunctionImpl;
 import org.wso2.carbon.identity.conditional.auth.functions.user.RemoveUserRolesV2Function;
@@ -90,6 +92,7 @@ public class UserFunctionsServiceComponent {
             RemoveUserRolesFunction removeUserRolesFunctionImpl = new RemoveUserRolesFunctionImpl();
             GetAssociatedLocalUserFunction getAssociatedLocalUserFunctionImpl = new GetAssociatedLocalUserFunctionImpl();
             SetAccountAssociationToLocalUser setAccountAssociationToLocalUserImpl = new SetAccountAssociationToLocalUserImpl();
+            RemoveAssociatedLocalUserFunction removeAssociatedLocalUserFunctionImpl = new RemoveAssociatedLocalUserFunctionImpl();
             MicrosoftEmailVerificationFunction microsoftEmailVerificationFunction = new MicrosoftEmailVerificationFunctionImpl();
             UpdateUserPasswordFunction updateUserPasswordFunction = new UpdateUserPasswordFunctionImpl();
 
@@ -129,6 +132,8 @@ public class UserFunctionsServiceComponent {
                     microsoftEmailVerificationFunction);
             jsFunctionRegistry.register(JsFunctionRegistry.Subsystem.SEQUENCE_HANDLER, "updateUserPassword",
                     updateUserPasswordFunction);
+            jsFunctionRegistry.register(JsFunctionRegistry.Subsystem.SEQUENCE_HANDLER, "removeAssociatedLocalUser",
+                    removeAssociatedLocalUserFunctionImpl);
         } catch (Throwable e) {
             LOG.error("Error occurred during conditional authentication user functions bundle activation. ", e);
         }


### PR DESCRIPTION
This PR introduces 2 new conditional auth functions. Please find the functions and their purposes below.

1. **getUsersWithClaimValues:** This method returns multiple users with values provided for the claims through adaptive script.
2. **removeAssociatedLocalUser:** This method will remove the local user association from a federated user.

Related issue:
- https://github.com/wso2/product-is/issues/25042