### PR TITLE
Import org.apache.http.impl.conn in the http functions bundle

### DIFF
--- a/components/org.wso2.carbon.identity.conditional.auth.functions.http/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.http/pom.xml
@@ -156,6 +156,7 @@
                             org.apache.http.client.methods,
                             org.apache.http.client.config,
                             org.apache.http.impl.client,
+                            org.apache.http.impl.conn,
                             org.apache.http.conn,
                             org.apache.http.message,
                             com.google.gson,


### PR DESCRIPTION
## Purpose

Fixes a runtime `NoClassDefFoundError` introduced by #230 in the conditional auth HTTP functions.

#230 changed `AbstractHTTPFunction` to size its connection pool with `PoolingHttpClientConnectionManager` (package `org.apache.http.impl.conn`), but the http functions bundle's `Import-Package` does not import that package. The code compiles (the jar is on the Maven classpath) but at OSGi runtime the class cannot be resolved:

```
java.lang.NoClassDefFoundError: org/apache/http/impl/conn/PoolingHttpClientConnectionManager
    at org.wso2.carbon.identity.conditional.auth.functions.http.AbstractHTTPFunction.<init>(AbstractHTTPFunction.java:88)
    at org.wso2.carbon.identity.conditional.auth.functions.http.internal.HTTPFunctionsServiceComponent.activate(HTTPFunctionsServiceComponent.java:65)
```

The component activation throws, so `httpGet` / `httpPost` are never registered and any adaptive script using them fails. This surfaced as product-is integration failures in `HttpMethodsTestCase` (`sessionDataKey ... is null`).

## Fix

Add `org.apache.http.impl.conn` to the http functions bundle `Import-Package` so `PoolingHttpClientConnectionManager` resolves at OSGi runtime.

Verified the generated bundle manifest now imports `org.apache.http.impl.conn`.